### PR TITLE
Add file processing tests and enhance file handling logic

### DIFF
--- a/FileProcessor.Testing/TestData.cs
+++ b/FileProcessor.Testing/TestData.cs
@@ -39,6 +39,7 @@ namespace FileProcessor.Testing
         public static String FilePathWithName = "home/txnproc/bulkfiles/Example.csv";
         public static String InProgressSafaricomFilePathWithName = "home/txnproc/bulkfiles/safaricom/inprogress/Example.csv";
         public static String FailedSafaricomFilePathWithName = "home/txnproc/bulkfiles/safaricom/failed/Example.csv";
+        public static String ProcessedSafaricomFilePathWithName = "home/txnproc/bulkfiles/safaricom/processed/Example.csv";
 
         public static Guid FileProfileId = Guid.Parse("D0D3A4E5-870E-42F6-AD0E-5E24252BC95E");
 


### PR DESCRIPTION
- Introduced a new test method to verify processing of uploaded files in the processed folder.
- Updated `FileProcessorDomainService` to check both processed and failed directories for file status.
- Enhanced file moving logic to allow overwriting existing files during moves.
- Added a new static path for processed Safaricom files in the `TestData` class.