### PR TITLE
Update NuGet package references across projects

### DIFF
--- a/FileProcessor.BusinessLogic/FileProcessor.BusinessLogic.csproj
+++ b/FileProcessor.BusinessLogic/FileProcessor.BusinessLogic.csproj
@@ -7,16 +7,16 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.5" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.7" />
-		<PackageReference Include="SecurityService.Client" Version="2025.7.1" />
-		<PackageReference Include="Shared" Version="2025.7.10" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.7.10" />
+		<PackageReference Include="SecurityService.Client" Version="2025.7.2" />
+		<PackageReference Include="Shared" Version="2025.7.13" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.7.13" />
 		<PackageReference Include="MediatR" Version="12.5.0" />
-		<PackageReference Include="Shared.EventStore" Version="2025.7.10" />
+		<PackageReference Include="Shared.EventStore" Version="2025.7.13" />
 		<PackageReference Include="System.IO.Abstractions" Version="22.0.14" />
-		<PackageReference Include="TransactionProcessor.Client" Version="2025.7.1" />
+		<PackageReference Include="TransactionProcessor.Client" Version="2025.7.2" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
-		<PackageReference Include="TransactionProcessor.Database" Version="2025.7.1" />
+		<PackageReference Include="TransactionProcessor.Database" Version="2025.7.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/FileProcessor.Client/FileProcessor.Client.csproj
+++ b/FileProcessor.Client/FileProcessor.Client.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2025.7.10" />
-    <PackageReference Include="Shared.Results" Version="2025.7.10" />
+    <PackageReference Include="ClientProxyBase" Version="2025.7.13" />
+    <PackageReference Include="Shared.Results" Version="2025.7.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FileProcessor.File.DomainEvents/FileProcessor.File.DomainEvents.csproj
+++ b/FileProcessor.File.DomainEvents/FileProcessor.File.DomainEvents.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.7.10" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.7.13" />
 	</ItemGroup>
 
 </Project>

--- a/FileProcessor.FileAggregate/FileProcessor.FileAggregate.csproj
+++ b/FileProcessor.FileAggregate/FileProcessor.FileAggregate.csproj
@@ -7,8 +7,8 @@
 	<ItemGroup>
 		<PackageReference Include="Grpc.Net.Client" Version="2.71.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.7" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.7.10" />
-		<PackageReference Include="Shared.EventStore" Version="2025.7.10" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.7.13" />
+		<PackageReference Include="Shared.EventStore" Version="2025.7.13" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/FileProcessor.FileImportLog.DomainEvents/FileProcessor.FileImportLog.DomainEvents.csproj
+++ b/FileProcessor.FileImportLog.DomainEvents/FileProcessor.FileImportLog.DomainEvents.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Shared.DomainDrivenDesign" Version="2025.7.10" />
+    <PackageReference Include="Shared.DomainDrivenDesign" Version="2025.7.13" />
   </ItemGroup>
 
 </Project>

--- a/FileProcessor.FileImportLogAggregate/FileProcessor.FileImportLogAggregate.csproj
+++ b/FileProcessor.FileImportLogAggregate/FileProcessor.FileImportLogAggregate.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Grpc.Net.Client" Version="2.71.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.7" />
-    <PackageReference Include="Shared.EventStore" Version="2025.7.10" />
+    <PackageReference Include="Shared.EventStore" Version="2025.7.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FileProcessor.IntegrationTesting.Helpers/FileProcessor.IntegrationTesting.Helpers.csproj
+++ b/FileProcessor.IntegrationTesting.Helpers/FileProcessor.IntegrationTesting.Helpers.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Shared.IntegrationTesting" Version="2025.7.10" />
-	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2025.7.1" />
+	  <PackageReference Include="Shared.IntegrationTesting" Version="2025.7.13" />
+	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2025.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FileProcessor.IntegrationTests/FileProcessor.IntegrationTests.csproj
+++ b/FileProcessor.IntegrationTests/FileProcessor.IntegrationTests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
 	  <PackageReference Include="EventStoreProjections" Version="2023.12.3" />
-	  <PackageReference Include="MessagingService.IntegrationTesting.Helpers" Version="2025.7.1" />
+	  <PackageReference Include="MessagingService.IntegrationTesting.Helpers" Version="2025.7.2" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
 	  <PackageReference Include="Ductus.FluentDocker" Version="2.10.59" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.5" />
@@ -22,13 +22,13 @@
 	  <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
 	  <PackageReference Include="Reqnroll" Version="2.4.1" />
 	  <PackageReference Include="Reqnroll.NUnit" Version="2.4.1" />
-    <PackageReference Include="SecurityService.Client" Version="2025.7.1" />
-    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2025.7.1" />
-	  <PackageReference Include="Shared" Version="2025.7.10" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2025.7.10" />
+    <PackageReference Include="SecurityService.Client" Version="2025.7.2" />
+    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2025.7.2" />
+	  <PackageReference Include="Shared" Version="2025.7.13" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2025.7.13" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-	  <PackageReference Include="TransactionProcessor.Client" Version="2025.7.1" />
-	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2025.7.1" />
+	  <PackageReference Include="TransactionProcessor.Client" Version="2025.7.2" />
+	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2025.7.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/FileProcessor/FileProcessor.csproj
+++ b/FileProcessor/FileProcessor.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="ClientProxyBase" Version="2025.7.10" />
+	  <PackageReference Include="ClientProxyBase" Version="2025.7.13" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.5" />
 	  <PackageReference Include="Lamar" Version="15.0.0" />
 	  <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />
@@ -19,12 +19,12 @@
 	  <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Shared" Version="2025.7.10" />
+    <PackageReference Include="Shared" Version="2025.7.13" />
 	  <PackageReference Include="NLog.Extensions.Logging" Version="5.5.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.5" />
-    <PackageReference Include="Shared.Results.Web" Version="2025.7.10" />
+    <PackageReference Include="Shared.Results.Web" Version="2025.7.13" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.3" />


### PR DESCRIPTION
Updated several NuGet packages to their latest versions, including `SecurityService.Client`, `Shared`, `Shared.DomainDrivenDesign`, `Shared.EventStore`, `TransactionProcessor.Client`, `TransactionProcessor.Database`, `ClientProxyBase`, `Shared.Results`, `Shared.IntegrationTesting`, `MessagingService.IntegrationTesting.Helpers`, and `TransactionProcessor.IntegrationTesting.Helpers`. The `EventStoreProjections` package was also updated. These changes may include bug fixes, new features, and performance improvements, reflecting a coordinated update across the solution.

closes #473 