### PR TITLE
Update NuGet package versions across all projects

### DIFF
--- a/FileProcessor.BusinessLogic.Tests/FileProcessor.BusinessLogic.Tests.csproj
+++ b/FileProcessor.BusinessLogic.Tests/FileProcessor.BusinessLogic.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="22.1.0" />

--- a/FileProcessor.BusinessLogic/FileProcessor.BusinessLogic.csproj
+++ b/FileProcessor.BusinessLogic/FileProcessor.BusinessLogic.csproj
@@ -7,16 +7,16 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-		<PackageReference Include="SecurityService.Client" Version="2025.12.2" />
-		<PackageReference Include="Shared" Version="2026.2.1" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.1" />
+		<PackageReference Include="SecurityService.Client" Version="2026.2.1" />
+		<PackageReference Include="Shared" Version="2026.2.2" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.2" />
 		<PackageReference Include="MediatR" Version="14.0.0" />
-		<PackageReference Include="Shared.EventStore" Version="2026.2.1" />
+		<PackageReference Include="Shared.EventStore" Version="2026.2.2" />
 		<PackageReference Include="System.IO.Abstractions" Version="22.1.0" />
-		<PackageReference Include="TransactionProcessor.Client" Version="2026.1.1" />
+		<PackageReference Include="TransactionProcessor.Client" Version="2026.2.1" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
-		<PackageReference Include="TransactionProcessor.Database" Version="2026.1.1" />
+		<PackageReference Include="TransactionProcessor.Database" Version="2026.2.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/FileProcessor.Client/FileProcessor.Client.csproj
+++ b/FileProcessor.Client/FileProcessor.Client.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.2.1" />
-    <PackageReference Include="Shared.Results" Version="2026.2.1" />
+    <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
+    <PackageReference Include="Shared.Results" Version="2026.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FileProcessor.File.DomainEvents/FileProcessor.File.DomainEvents.csproj
+++ b/FileProcessor.File.DomainEvents/FileProcessor.File.DomainEvents.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.1" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.2" />
 	</ItemGroup>
 
 </Project>

--- a/FileProcessor.FileAggregate.Tests/FileProcessor.FileAggregate.Tests.csproj
+++ b/FileProcessor.FileAggregate.Tests/FileProcessor.FileAggregate.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/FileProcessor.FileAggregate/FileProcessor.FileAggregate.csproj
+++ b/FileProcessor.FileAggregate/FileProcessor.FileAggregate.csproj
@@ -7,8 +7,8 @@
 	<ItemGroup>
 		<PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.1" />
-		<PackageReference Include="Shared.EventStore" Version="2026.2.1" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.2" />
+		<PackageReference Include="Shared.EventStore" Version="2026.2.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/FileProcessor.FileImportLog.DomainEvents/FileProcessor.FileImportLog.DomainEvents.csproj
+++ b/FileProcessor.FileImportLog.DomainEvents/FileProcessor.FileImportLog.DomainEvents.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.1" />
+    <PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.2" />
   </ItemGroup>
 
 </Project>

--- a/FileProcessor.FileImportLogAggregate.Tests/FileProcessor.FileImportLogAggregate.Tests.csproj
+++ b/FileProcessor.FileImportLogAggregate.Tests/FileProcessor.FileImportLogAggregate.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/FileProcessor.FileImportLogAggregate/FileProcessor.FileImportLogAggregate.csproj
+++ b/FileProcessor.FileImportLogAggregate/FileProcessor.FileImportLogAggregate.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Shared.EventStore" Version="2026.2.1" />
+    <PackageReference Include="Shared.EventStore" Version="2026.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FileProcessor.IntegrationTesting.Helpers/FileProcessor.IntegrationTesting.Helpers.csproj
+++ b/FileProcessor.IntegrationTesting.Helpers/FileProcessor.IntegrationTesting.Helpers.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.1" />
-	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.1.1" />
+	  <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.2" />
+	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FileProcessor.IntegrationTests/FileProcessor.IntegrationTests.csproj
+++ b/FileProcessor.IntegrationTests/FileProcessor.IntegrationTests.csproj
@@ -12,23 +12,23 @@
 
   <ItemGroup>
 	  <PackageReference Include="EventStoreProjections" Version="2023.12.3" />
-	  <PackageReference Include="MessagingService.IntegrationTesting.Helpers" Version="2025.12.1" />
+	  <PackageReference Include="MessagingService.IntegrationTesting.Helpers" Version="2026.2.1" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
 	  <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.3" />
 	  <PackageReference Include="NUnit" Version="4.5.0" />
 	  <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
 	  <PackageReference Include="Reqnroll" Version="3.3.3" />
 	  <PackageReference Include="Reqnroll.NUnit" Version="3.3.3" />
-    <PackageReference Include="SecurityService.Client" Version="2025.12.2" />
-    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2025.12.2" />
-	  <PackageReference Include="Shared" Version="2026.2.1" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.1" />
+    <PackageReference Include="SecurityService.Client" Version="2026.2.1" />
+    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.2.1" />
+	  <PackageReference Include="Shared" Version="2026.2.2" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.2" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-	  <PackageReference Include="TransactionProcessor.Client" Version="2026.1.1" />
-	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.1.1" />
+	  <PackageReference Include="TransactionProcessor.Client" Version="2026.2.1" />
+	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.2.1" />
     <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/FileProcessor.Tests/FileProcessor.Tests.csproj
+++ b/FileProcessor.Tests/FileProcessor.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Shouldly" Version="4.3.0" />

--- a/FileProcessor/FileProcessor.csproj
+++ b/FileProcessor/FileProcessor.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="ClientProxyBase" Version="2026.2.1" />
+	  <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
 	  <PackageReference Include="Lamar" Version="15.0.1" />
 	  <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
@@ -17,10 +17,10 @@
 	  <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Shared" Version="2026.2.1" />
+    <PackageReference Include="Shared" Version="2026.2.2" />
 	  <PackageReference Include="NLog.Extensions.Logging" Version="6.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
-    <PackageReference Include="Shared.Results.Web" Version="2026.2.1" />
+    <PackageReference Include="Shared.Results.Web" Version="2026.2.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />


### PR DESCRIPTION
Upgraded multiple NuGet dependencies to their latest versions, including Shared, ClientProxyBase, SecurityService.Client, TransactionProcessor.Client, MessagingService.IntegrationTesting.Helpers, and others. Also updated Microsoft.NET.Test.Sdk to 18.3.0 in all test projects. No code changes; only .csproj dependency updates.

closes #678 