### PR TITLE
Update dependencies and simplify MediatR registration

### DIFF
--- a/FileProcessor.BusinessLogic/FileProcessor.BusinessLogic.csproj
+++ b/FileProcessor.BusinessLogic/FileProcessor.BusinessLogic.csproj
@@ -7,16 +7,16 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-		<PackageReference Include="SecurityService.Client" Version="2026.2.1" />
-		<PackageReference Include="Shared" Version="2026.2.2" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.2" />
-		<PackageReference Include="MediatR" Version="14.0.0" />
-		<PackageReference Include="Shared.EventStore" Version="2026.2.2" />
+		<PackageReference Include="SecurityService.Client" Version="2026.2.3" />
+		<PackageReference Include="Shared" Version="2026.3.1" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.3.1" />
+		<PackageReference Include="MediatR" Version="14.1.0" />
+		<PackageReference Include="Shared.EventStore" Version="2026.3.1" />
 		<PackageReference Include="System.IO.Abstractions" Version="22.1.0" />
-		<PackageReference Include="TransactionProcessor.Client" Version="2026.2.1" />
+		<PackageReference Include="TransactionProcessor.Client" Version="2026.3.1" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
-		<PackageReference Include="TransactionProcessor.Database" Version="2026.2.1" />
+		<PackageReference Include="TransactionProcessor.Database" Version="2026.3.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/FileProcessor.Client/FileProcessor.Client.csproj
+++ b/FileProcessor.Client/FileProcessor.Client.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
-    <PackageReference Include="Shared.Results" Version="2026.2.2" />
+    <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
+    <PackageReference Include="Shared.Results" Version="2026.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FileProcessor.File.DomainEvents/FileProcessor.File.DomainEvents.csproj
+++ b/FileProcessor.File.DomainEvents/FileProcessor.File.DomainEvents.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.2" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.3.1" />
 	</ItemGroup>
 
 </Project>

--- a/FileProcessor.FileAggregate/FileProcessor.FileAggregate.csproj
+++ b/FileProcessor.FileAggregate/FileProcessor.FileAggregate.csproj
@@ -7,8 +7,8 @@
 	<ItemGroup>
 		<PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.2" />
-		<PackageReference Include="Shared.EventStore" Version="2026.2.2" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.3.1" />
+		<PackageReference Include="Shared.EventStore" Version="2026.3.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/FileProcessor.FileImportLog.DomainEvents/FileProcessor.FileImportLog.DomainEvents.csproj
+++ b/FileProcessor.FileImportLog.DomainEvents/FileProcessor.FileImportLog.DomainEvents.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.2" />
+    <PackageReference Include="Shared.DomainDrivenDesign" Version="2026.3.1" />
   </ItemGroup>
 
 </Project>

--- a/FileProcessor.FileImportLogAggregate/FileProcessor.FileImportLogAggregate.csproj
+++ b/FileProcessor.FileImportLogAggregate/FileProcessor.FileImportLogAggregate.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Shared.EventStore" Version="2026.2.2" />
+    <PackageReference Include="Shared.EventStore" Version="2026.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FileProcessor.IntegrationTesting.Helpers/FileProcessor.IntegrationTesting.Helpers.csproj
+++ b/FileProcessor.IntegrationTesting.Helpers/FileProcessor.IntegrationTesting.Helpers.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.2" />
-	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.2.1" />
+	  <PackageReference Include="Shared.IntegrationTesting" Version="2026.3.1" />
+	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FileProcessor.IntegrationTests/FileProcessor.IntegrationTests.csproj
+++ b/FileProcessor.IntegrationTests/FileProcessor.IntegrationTests.csproj
@@ -12,23 +12,23 @@
 
   <ItemGroup>
 	  <PackageReference Include="EventStoreProjections" Version="2023.12.3" />
-	  <PackageReference Include="MessagingService.IntegrationTesting.Helpers" Version="2026.2.1" />
+	  <PackageReference Include="MessagingService.IntegrationTesting.Helpers" Version="2026.2.2" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
 	  <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.3" />
-	  <PackageReference Include="NUnit" Version="4.5.0" />
+	  <PackageReference Include="NUnit" Version="4.5.1" />
 	  <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
 	  <PackageReference Include="Reqnroll" Version="3.3.3" />
 	  <PackageReference Include="Reqnroll.NUnit" Version="3.3.3" />
-    <PackageReference Include="SecurityService.Client" Version="2026.2.1" />
-    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.2.1" />
-	  <PackageReference Include="Shared" Version="2026.2.2" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.2" />
+    <PackageReference Include="SecurityService.Client" Version="2026.2.3" />
+    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.2.3" />
+	  <PackageReference Include="Shared" Version="2026.3.1" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.3.1" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-	  <PackageReference Include="TransactionProcessor.Client" Version="2026.2.1" />
-	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.2.1" />
+	  <PackageReference Include="TransactionProcessor.Client" Version="2026.3.1" />
+	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.3.1" />
     <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/FileProcessor/Bootstrapper/MediatorRegistry.cs
+++ b/FileProcessor/Bootstrapper/MediatorRegistry.cs
@@ -22,16 +22,7 @@ public class MediatorRegistry : ServiceRegistry
     /// </summary>
     public MediatorRegistry()
     {
-        this.AddSingleton<IMediator, Mediator>();
-        // request & notification handlers
-
-        this.AddSingleton<IRequestHandler<FileCommands.ProcessTransactionForFileLineCommand, Result>, FileRequestHandler>();
-        this.AddSingleton<IRequestHandler<FileCommands.ProcessUploadedFileCommand, Result>, FileRequestHandler>();
-        this.AddSingleton<IRequestHandler<FileCommands.UploadFileCommand, Result<Guid>>, FileRequestHandler>();
-        
-        this.AddSingleton<IRequestHandler<FileQueries.GetFileQuery, Result<FileDetails>>, FileRequestHandler>();
-        this.AddSingleton<IRequestHandler<FileQueries.GetImportLogQuery, Result<Models.FileImportLog>>, FileRequestHandler>();
-        this.AddSingleton<IRequestHandler<FileQueries.GetImportLogsQuery, Result<List<Models.FileImportLog>>>, FileRequestHandler>();
+        this.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(FileRequestHandler).Assembly));
     }
 
     #endregion

--- a/FileProcessor/FileProcessor.csproj
+++ b/FileProcessor/FileProcessor.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
+	  <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
 	  <PackageReference Include="Lamar" Version="15.0.1" />
 	  <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
@@ -17,10 +17,10 @@
 	  <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Shared" Version="2026.2.2" />
-	  <PackageReference Include="NLog.Extensions.Logging" Version="6.1.1" />
+    <PackageReference Include="Shared" Version="2026.3.1" />
+	  <PackageReference Include="NLog.Extensions.Logging" Version="6.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
-    <PackageReference Include="Shared.Results.Web" Version="2026.2.2" />
+    <PackageReference Include="Shared.Results.Web" Version="2026.3.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />

--- a/FileProcessor/Startup.cs
+++ b/FileProcessor/Startup.cs
@@ -118,8 +118,7 @@ namespace FileProcessor
 
             ConfigurationReader.Initialise(Startup.Configuration);
             app.UseMiddleware<TenantMiddleware>();
-            app.AddRequestLogging();
-            app.AddResponseLogging();
+            app.AddRequestResponseLogging();
             app.AddExceptionHandler();
             
             app.UseRouting();


### PR DESCRIPTION
- Bump versions of internal and third-party NuGet packages
- Replace explicit MediatR handler registration with assembly scanning
- Consolidate request/response logging middleware in Startup
- No changes to business logic; improvements are infra/DI only
closes #684 