### PR TITLE
Add Sentry integration and centralize config loading

### DIFF
--- a/.github/workflows/createrelease.yml
+++ b/.github/workflows/createrelease.yml
@@ -49,6 +49,10 @@ jobs:
     - name: Publish API
       if: ${{ github.event.release.prerelease == false }}
       run: dotnet publish "FileProcessor\FileProcessor.csproj" --configuration Release --output publishOutput -r win-x64 --self-contained
+              -p:Version=${{ steps.get_version.outputs.VERSION }}
+              -p:AssemblyVersion=${{ steps.get_version.outputs.VERSION }}
+              -p:FileVersion=${{ steps.get_version.outputs.VERSION }}
+              -p:InformationalVersion=${{ steps.get_version.outputs.VERSION }}
     
     - name: Build Release Package
       run: |

--- a/FileProcessor/FileProcessor.csproj
+++ b/FileProcessor/FileProcessor.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.4" />
 	  <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.3" />
+	  <PackageReference Include="Sentry.AspNetCore" Version="6.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FileProcessor/Program.cs
+++ b/FileProcessor/Program.cs
@@ -19,12 +19,15 @@ namespace FileProcessor
     using Microsoft.Extensions.DependencyInjection;
     using NLog;
     using NLog.Extensions.Logging;
+    using Sentry.Extensibility;
     using Shared.EventStore.EventHandling;
+    using Shared.General;
     using Shared.Logger;
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.IO.Abstractions;
     using System.Net.Http;
+    using System.Reflection;
 
     [ExcludeFromCodeCoverage]
     public class Program
@@ -68,6 +71,45 @@ namespace FileProcessor
                                          });
             hostBuilder.ConfigureWebHostDefaults(webBuilder =>
                                                  {
+                                                     webBuilder.ConfigureAppConfiguration((context, configBuilder) =>
+                                                     {
+                                                         var env = context.HostingEnvironment;
+
+                                                         configBuilder.SetBasePath(fi.Directory.FullName)
+                                                             .AddJsonFile("hosting.json", optional: true)
+                                                             .AddJsonFile($"hosting.{env.EnvironmentName}.json", optional: true)
+                                                             .AddJsonFile("/home/txnproc/config/appsettings.json", optional: true, reloadOnChange: true)
+                                                             .AddJsonFile($"/home/txnproc/config/appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true)
+                                                             .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                                                             .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true)
+                                                             .AddEnvironmentVariables();
+
+                                                         // Build a snapshot of configuration so we can use it immediately (e.g. for Sentry)
+                                                         var builtConfig = configBuilder.Build();
+
+                                                         // Keep existing static usage (if you must), and initialise the ConfigurationReader now.
+                                                         Startup.Configuration = builtConfig;
+                                                         ConfigurationReader.Initialise(Startup.Configuration);
+
+                                                         // Configure Sentry on the webBuilder using the config snapshot.
+                                                         var sentrySection = builtConfig.GetSection("SentryConfiguration");
+                                                         if (sentrySection.Exists())
+                                                         {
+                                                             // Replace the condition below if you intended to only enable Sentry in certain environments.
+                                                             if (env.IsDevelopment() == false)
+                                                             {
+                                                                 webBuilder.UseSentry(o =>
+                                                                 {
+                                                                     o.Dsn = builtConfig["SentryConfiguration:Dsn"];
+                                                                     o.SendDefaultPii = true;
+                                                                     o.MaxRequestBodySize = RequestSize.Always;
+                                                                     o.CaptureBlockingCalls = true;
+                                                                     o.Release = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
+                                                                 });
+                                                             }
+                                                         }
+                                                     });
+
                                                      webBuilder.UseStartup<Startup>();
                                                      webBuilder.UseConfiguration(config);
                                                      webBuilder.UseKestrel();

--- a/FileProcessor/Startup.cs
+++ b/FileProcessor/Startup.cs
@@ -48,14 +48,6 @@ namespace FileProcessor
 
         public Startup(IWebHostEnvironment webHostEnvironment)
         {
-            IConfigurationBuilder builder = new ConfigurationBuilder().SetBasePath(webHostEnvironment.ContentRootPath)
-                                                                      .AddJsonFile("/home/txnproc/config/appsettings.json", true, true)
-                                                                      .AddJsonFile($"/home/txnproc/config/appsettings.{webHostEnvironment.EnvironmentName}.json", optional: true)
-                                                                      .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                                                                      .AddJsonFile($"appsettings.{webHostEnvironment.EnvironmentName}.json", optional: true, reloadOnChange: true)
-                                                                      .AddEnvironmentVariables();
-
-            Startup.Configuration = builder.Build();
             Startup.WebHostEnvironment = webHostEnvironment;
         }
         


### PR DESCRIPTION
- Integrate Sentry.AspNetCore for error monitoring in non-development environments, loading DSN and options from configuration.
- Move configuration building from Startup.cs to Program.cs for earlier access, supporting Sentry setup.
- Update Startup to use pre-built configuration.
- Enhance GitHub Actions release workflow to set versioning properties during publish.
- Centralize and streamline configuration loading for consistency.
closes #691 
closes #690 