### PR TITLE
Make Sentry options configurable via app settings

### DIFF
--- a/FileProcessor/Program.cs
+++ b/FileProcessor/Program.cs
@@ -103,7 +103,8 @@ namespace FileProcessor
                                                                      o.Dsn = builtConfig["SentryConfiguration:Dsn"];
                                                                      o.SendDefaultPii = true;
                                                                      o.MaxRequestBodySize = RequestSize.Always;
-                                                                     o.CaptureBlockingCalls = true;
+                                                                     o.CaptureBlockingCalls = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "CaptureBlockingCalls", false);
+                                                                     o.IncludeActivityData = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "IncludeActivityData", false);
                                                                      o.Release = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
                                                                  });
                                                              }


### PR DESCRIPTION
Refactored Sentry configuration to read CaptureBlockingCalls and the new IncludeActivityData options from application settings using ConfigurationReader, allowing for more flexible and environment-specific configuration. Defaults for both options are set to false if not specified.

closes #693 