### PR TITLE
Remove unit tests from release, update trace log paths

### DIFF
--- a/.github/workflows/createrelease.yml
+++ b/.github/workflows/createrelease.yml
@@ -23,14 +23,7 @@ jobs:
       run: dotnet restore FileProcessor.sln --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }}
 
     - name: Build Code
-      run: dotnet build FileProcessor.sln --configuration Release
-
-    - name: Run Unit Tests
-      run: |
-        echo "ASPNETCORE_ENVIRONMENT are > ${ASPNETCORE_ENVIRONMENT}"
-        dotnet test "FileProcessor.BusinessLogic.Tests\FileProcessor.BusinessLogic.Tests.csproj"
-        dotnet test "FileProcessor.FileAggregate.Tests\FileProcessor.FileAggregate.Tests.csproj"
-        dotnet test "FileProcessor.FileImportLogAggregate.Tests\FileProcessor.FileImportLogAggregate.Tests.csproj"      
+      run: dotnet build FileProcessor.sln --configuration Release      
 
     - name: Publish Images to Docker Hub - Pre Release
       if: ${{ github.event.release.prerelease == true }} 

--- a/.github/workflows/nightlybuild.yml
+++ b/.github/workflows/nightlybuild.yml
@@ -38,11 +38,10 @@ jobs:
     - name: Run Integration Tests        
       run: dotnet test "FileProcessor.IntegrationTests\FileProcessor.IntegrationTests.csproj"    
 
-    - uses: actions/upload-artifact@v4.4.0
-      if: ${{ failure() }}
+    - uses: actions/upload-artifact@v4.4.0      
       with:
         name: tracelogs
-        path: /home/txnproc/trace/     
+        path: /home/runner/trace/     
     
     - uses: dacbd/create-issue-action@main
       if: ${{ failure() }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -41,10 +41,9 @@ jobs:
       run: dotnet test "FileProcessor.IntegrationTests\FileProcessor.IntegrationTests.csproj" --filter Category=PRTest  --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=integration-test-results.trx"
 
     - uses: actions/upload-artifact@v4.4.0
-      if: ${{ failure() }}
       with:
         name: tracelogs
-        path: /home/txnproc/trace/         
+        path: /home/runner/trace/         
 
     - name: Publish test results
       uses: dorny/test-reporter@v1


### PR DESCRIPTION
Removed unit test execution from createrelease.yml. Updated trace log artifact paths to /home/runner/trace/ in nightlybuild.yml and pullrequest.yml. Artifact upload in nightlybuild.yml now runs unconditionally.

closes #704 