### PR TITLE
Deterministic FileId, System.Text.Json, serialization revamp

### DIFF
--- a/FileProcessor.BusinessLogic.Tests/DummyFileProcessorDomainService.cs
+++ b/FileProcessor.BusinessLogic.Tests/DummyFileProcessorDomainService.cs
@@ -14,9 +14,9 @@ using Services;
 
 public class DummyFileProcessorDomainService : IFileProcessorDomainService {
 
-    public async Task<Result<Guid>> UploadFile(FileCommands.UploadFileCommand command,
+    public async Task<Result> UploadFile(FileCommands.UploadFileCommand command,
                                                CancellationToken cancellationToken) =>
-        Result.Success(Guid.NewGuid());
+        Result.Success();
 
     public async Task<Result> ProcessUploadedFile(FileCommands.ProcessUploadedFileCommand command,
                                                   CancellationToken cancellationToken) => Result.Success();

--- a/FileProcessor.BusinessLogic.Tests/FileProcessorDomainServiceTests.cs
+++ b/FileProcessor.BusinessLogic.Tests/FileProcessorDomainServiceTests.cs
@@ -1,4 +1,5 @@
-﻿using SimpleResults;
+﻿using System.Text;
+using SimpleResults;
 using TransactionProcessor.DataTransferObjects.Responses.Contract;
 using TransactionProcessor.DataTransferObjects.Responses.Operator;
 
@@ -88,12 +89,15 @@ public class FileProcessorDomainServiceTests
         this.FileImportLogAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.GetEmptyFileImportLogAggregate()));
         this.FileImportLogAggregateRepository.Setup(f => f.SaveChanges(It.IsAny<FileImportLogAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success());
 
-        this.FileSystem.AddFile(TestData.FilePathWithName, new MockFileData("D,1,1,1"));
+        var m = new MockFileData("D,1,1,1");
+        var fileId = FileProcessorDomainService.CreateGuidFromFileData(Encoding.UTF8.GetString(m.Contents));
+        this.FileSystem.AddFile(TestData.FilePathWithName, m);
         this.FileSystem.AddDirectory("home/txnproc/bulkfiles/safaricom");
         
-        Result<Guid> result = await this.FileProcessorDomainService.UploadFile(TestData.UploadFileCommand, CancellationToken.None);
+        var command = TestData.UploadFileCommand with { FileId = fileId };
+
+        Result result = await this.FileProcessorDomainService.UploadFile(command, CancellationToken.None);
         result.IsSuccess.ShouldBeTrue();
-        result.Data.ShouldNotBe(Guid.Empty);
     }
 
     [Fact]
@@ -160,12 +164,15 @@ public class FileProcessorDomainServiceTests
         this.FileImportLogAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.GetCreatedFileImportLogAggregate()));
         this.FileImportLogAggregateRepository.Setup(f => f.SaveChanges(It.IsAny<FileImportLogAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success());
 
-        this.FileSystem.AddFile(TestData.FilePathWithName, new MockFileData("D,1,1,1"));
+        var m = new MockFileData("D,1,1,1");
+        var fileId = FileProcessorDomainService.CreateGuidFromFileData(Encoding.UTF8.GetString(m.Contents));
+        this.FileSystem.AddFile(TestData.FilePathWithName, m);
         this.FileSystem.AddDirectory("home/txnproc/bulkfiles/safaricom");
 
-        Result<Guid> result = await this.FileProcessorDomainService.UploadFile(TestData.UploadFileCommand, CancellationToken.None);
+        var command = TestData.UploadFileCommand with { FileId = fileId };
+
+        Result result = await this.FileProcessorDomainService.UploadFile(command, CancellationToken.None);
         result.IsSuccess.ShouldBeTrue();
-        result.Data.ShouldNotBe(Guid.Empty);
     }
 
     [Fact]
@@ -500,8 +507,8 @@ public class FileProcessorDomainServiceTests
         this.FileAggregateRepository.Setup(f => f.SaveChanges(It.IsAny<FileAggregate>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success);
 
-        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SerialisedMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(TestData.SerialisedMessageResponseSale);
+        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SaleTransactionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestData.ClientSaleTransactionResponse);
             
         this.TransactionProcessorClient.Setup(e => e.GetMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(TestData.GetMerchantResponseWithOperator);
@@ -529,8 +536,8 @@ public class FileProcessorDomainServiceTests
         this.FileAggregateRepository.Setup(f => f.SaveChanges(It.IsAny<FileAggregate>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Failure);
 
-        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SerialisedMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(TestData.SerialisedMessageResponseSale);
+        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SaleTransactionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestData.ClientSaleTransactionResponse);
 
         this.TransactionProcessorClient.Setup(e => e.GetMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(TestData.GetMerchantResponseWithOperator);
@@ -558,8 +565,8 @@ public class FileProcessorDomainServiceTests
         this.FileAggregateRepository.Setup(f => f.SaveChanges(It.IsAny<FileAggregate>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception());
 
-        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SerialisedMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(TestData.SerialisedMessageResponseSale);
+        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SaleTransactionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestData.ClientSaleTransactionResponse);
 
         this.TransactionProcessorClient.Setup(e => e.GetMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(TestData.GetMerchantResponseWithOperator);
@@ -586,8 +593,8 @@ public class FileProcessorDomainServiceTests
         this.FileAggregateRepository.Setup(f => f.SaveChanges(It.IsAny<FileAggregate>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success);
 
-        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SerialisedMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(TestData.SerialisedMessageResponseSale);
+        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SaleTransactionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestData.ClientSaleTransactionResponse);
 
         this.TransactionProcessorClient.Setup(e => e.GetMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(TestData.GetMerchantResponseWithOperator);
@@ -687,8 +694,8 @@ public class FileProcessorDomainServiceTests
         this.FileAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.GetFileAggregateWithLines()));
         this.FileAggregateRepository.Setup(f => f.SaveChanges(It.IsAny<FileAggregate>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success);
-        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SerialisedMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(TestData.SerialisedMessageResponseSale);
+        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SaleTransactionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestData.ClientSaleTransactionResponse);
 
         this.TransactionProcessorClient.Setup(e => e.GetMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(TestData.GetMerchantResponseWithOperator);
@@ -712,8 +719,8 @@ public class FileProcessorDomainServiceTests
 
         this.FileAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.GetFileAggregateWithBlankLine()));
         
-        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SerialisedMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(TestData.SerialisedMessageResponseSale);
+        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SaleTransactionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestData.ClientSaleTransactionResponse);
 
         this.TransactionProcessorClient.Setup(e => e.GetMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(TestData.GetMerchantResponseWithOperator);
@@ -734,8 +741,8 @@ var result =                             await this.FileProcessorDomainService.P
         this.FileAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.GetFileAggregateWithLines()));
         this.FileAggregateRepository.Setup(f => f.SaveChanges(It.IsAny<FileAggregate>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success);
-        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SerialisedMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(TestData.SerialisedMessageResponseSale);
+        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SaleTransactionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestData.ClientSaleTransactionResponse);
 
         this.TransactionProcessorClient.Setup(e => e.GetMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(TestData.GetMerchantResponseWithOperator);
@@ -760,8 +767,8 @@ var result =                             await this.FileProcessorDomainService.P
 
         this.FileAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.GetFileAggregateWithLines()));
 
-        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SerialisedMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(TestData.SerialisedMessageResponseSale);
+        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SaleTransactionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestData.ClientSaleTransactionResponse);
 
         this.TransactionProcessorClient
             .Setup(e => e.GetMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(),
@@ -786,8 +793,8 @@ var result =                             await this.FileProcessorDomainService.P
 
         this.FileAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.GetFileAggregateWithLines()));
 
-        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SerialisedMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(TestData.SerialisedMessageResponseSale);
+        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SaleTransactionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestData.ClientSaleTransactionResponse);
 
         this.TransactionProcessorClient.Setup(e => e.GetMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(TestData.GetMerchantResponseWithOperator);
@@ -812,8 +819,8 @@ var result =                             await this.FileProcessorDomainService.P
 
         this.FileAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.GetFileAggregateWithLines()));
 
-        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SerialisedMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(TestData.SerialisedMessageResponseSale);
+        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SaleTransactionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestData.ClientSaleTransactionResponse);
 
         this.TransactionProcessorClient.Setup(e => e.GetMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(TestData.GetMerchantResponseWithOperator);
@@ -838,8 +845,8 @@ var result =                             await this.FileProcessorDomainService.P
 
         this.FileAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.GetFileAggregateWithLines()));
 
-        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SerialisedMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(TestData.SerialisedMessageResponseSale);
+        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SaleTransactionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestData.ClientSaleTransactionResponse);
 
         this.TransactionProcessorClient.Setup(e => e.GetMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(TestData.GetMerchantResponseWithOperator);
@@ -868,8 +875,8 @@ var result =                             await this.FileProcessorDomainService.P
 
         this.FileAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.GetFileAggregateWithLines()));
 
-        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SerialisedMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(TestData.SerialisedMessageResponseSale);
+        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SaleTransactionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestData.ClientSaleTransactionResponse);
 
         this.TransactionProcessorClient.Setup(e => e.GetMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(TestData.GetMerchantResponseWithOperator);
@@ -894,8 +901,8 @@ var result =                             await this.FileProcessorDomainService.P
 
         this.FileAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.GetFileAggregateWithLines()));
 
-        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SerialisedMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(TestData.SerialisedMessageResponseSale);
+        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SaleTransactionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestData.ClientSaleTransactionResponse);
 
         this.TransactionProcessorClient.Setup(e => e.GetMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(TestData.GetMerchantResponseWithOperator);
@@ -920,7 +927,7 @@ var result =                             await this.FileProcessorDomainService.P
 
         this.FileAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.GetFileAggregateWithLines()));
 
-        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SerialisedMessage>(), It.IsAny<CancellationToken>()))
+        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SaleTransactionRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Failure());
 
         this.TransactionProcessorClient.Setup(e => e.GetMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
@@ -946,8 +953,8 @@ var result =                             await this.FileProcessorDomainService.P
 
         this.FileAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.GetFileAggregateWithLines()));
 
-        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SerialisedMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(TestData.SerialisedMessageResponseFailedSale);
+        this.TransactionProcessorClient.Setup(t => t.PerformTransaction(It.IsAny<String>(), It.IsAny<SaleTransactionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestData.ClientSaleTransactionFailedResponse);
 
         this.TransactionProcessorClient.Setup(e => e.GetMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(TestData.GetMerchantResponseWithOperator);

--- a/FileProcessor.BusinessLogic/EventHandling/FileDomainEventHandler.cs
+++ b/FileProcessor.BusinessLogic/EventHandling/FileDomainEventHandler.cs
@@ -1,28 +1,16 @@
-﻿using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+using Shared.Logger;
 using SimpleResults;
 
 namespace FileProcessor.BusinessLogic.EventHandling
 {
     using System.Threading;
     using File.DomainEvents;
-    using FileAggregate;
     using FileImportLog.DomainEvents;
-    using Managers;
     using MediatR;
-    using Microsoft.Extensions.Logging;
-    using Newtonsoft.Json;
     using Requests;
-    using SecurityService.Client;
-    using SecurityService.DataTransferObjects.Responses;
     using Shared.DomainDrivenDesign.EventSourcing;
-    using Shared.EventStore.Aggregate;
     using Shared.EventStore.EventHandling;
-    using Shared.General;
-    using Shared.Logger;
-    using TransactionProcessor.Client;
-    using TransactionProcessor.DataTransferObjects;
 
     /// <summary>
     /// 

--- a/FileProcessor.BusinessLogic/FileProcessor.BusinessLogic.csproj
+++ b/FileProcessor.BusinessLogic/FileProcessor.BusinessLogic.csproj
@@ -7,16 +7,16 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-		<PackageReference Include="SecurityService.Client" Version="2026.2.3" />
-		<PackageReference Include="Shared" Version="2026.3.1" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.3.1" />
+		<PackageReference Include="SecurityService.Client" Version="2026.4.3-build157" />
+		<PackageReference Include="Shared" Version="2026.5.6" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.6" />
 		<PackageReference Include="MediatR" Version="14.1.0" />
-		<PackageReference Include="Shared.EventStore" Version="2026.3.1" />
+		<PackageReference Include="Shared.EventStore" Version="2026.5.6" />
 		<PackageReference Include="System.IO.Abstractions" Version="22.1.0" />
-		<PackageReference Include="TransactionProcessor.Client" Version="2026.3.2" />
+		<PackageReference Include="TransactionProcessor.Client" Version="2026.4.3-build355" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
-		<PackageReference Include="TransactionProcessor.Database" Version="2026.3.2" />
+		<PackageReference Include="TransactionProcessor.Database" Version="2026.4.3-build355" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/FileProcessor.BusinessLogic/RequestHandlers/FileRequestHandler.cs
+++ b/FileProcessor.BusinessLogic/RequestHandlers/FileRequestHandler.cs
@@ -14,7 +14,7 @@ namespace FileProcessor.BusinessLogic.RequestHandlers
     
     public class FileRequestHandler : IRequestHandler<FileCommands.ProcessTransactionForFileLineCommand,Result>,
                                       IRequestHandler<FileCommands.ProcessUploadedFileCommand, Result>,
-                                      IRequestHandler<FileCommands.UploadFileCommand, Result<Guid>>,
+                                      IRequestHandler<FileCommands.UploadFileCommand, Result>,
                                       IRequestHandler<FileQueries.GetFileQuery, Result<FileDetails>>,
                                       IRequestHandler<FileQueries.GetImportLogsQuery, Result<List<Models.FileImportLog>>>,
                                       IRequestHandler<FileQueries.GetImportLogQuery, Result<Models.FileImportLog>>
@@ -27,7 +27,7 @@ namespace FileProcessor.BusinessLogic.RequestHandlers
             this.Manager = manager;
         }
         
-        public async Task<Result<Guid>> Handle(FileCommands.UploadFileCommand command,
+        public async Task<Result> Handle(FileCommands.UploadFileCommand command,
                                                CancellationToken cancellationToken) {
             return await this.DomainService.UploadFile(command, cancellationToken);
         }

--- a/FileProcessor.BusinessLogic/Requests/FileCommands.cs
+++ b/FileProcessor.BusinessLogic/Requests/FileCommands.cs
@@ -19,10 +19,11 @@ public record FileCommands {
                                              Guid FileProfileId,
                                              DateTime FileUploadedDateTime) : IRequest<Result>;
 
-    public record UploadFileCommand(Guid EstateId,
+    public record UploadFileCommand(Guid FileId,
+                                    Guid EstateId,
                                     Guid MerchantId,
                                     Guid UserId,
                                     String FilePath,
                                     Guid FileProfileId,
-                                    DateTime FileUploadedDateTime) : IRequest<Result<Guid>>;
+                                    DateTime FileUploadedDateTime) : IRequest<Result>;
 }

--- a/FileProcessor.BusinessLogic/Services/FileProcessorDomainService.cs
+++ b/FileProcessor.BusinessLogic/Services/FileProcessorDomainService.cs
@@ -1,4 +1,5 @@
-﻿using Shared.EventStore.Helpers;
+﻿using SecurityService.DataTransferObjects;
+using Shared.EventStore.Helpers;
 using TransactionProcessor.DataTransferObjects.Responses.Merchant;
 
 namespace FileProcessor.BusinessLogic.Services;
@@ -23,10 +24,8 @@ using FileFormatHandlers;
 using FileImportLogAggregate;
 using Models;
 using Managers;
-using Newtonsoft.Json;
 using Requests;
 using SecurityService.Client;
-using SecurityService.DataTransferObjects.Responses;
 using Shared.DomainDrivenDesign.EventSourcing;
 using Shared.EventStore.Aggregate;
 using Shared.Exceptions;
@@ -39,7 +38,7 @@ using FileLine = Models.FileLine;
 
 public interface IFileProcessorDomainService
 {
-    Task<Result<Guid>> UploadFile(FileCommands.UploadFileCommand command, CancellationToken cancellationToken);
+    Task<Result> UploadFile(FileCommands.UploadFileCommand command, CancellationToken cancellationToken);
 
     Task<Result> ProcessUploadedFile(FileCommands.ProcessUploadedFileCommand command,
                                      CancellationToken cancellationToken);
@@ -110,7 +109,7 @@ public class FileProcessorDomainService : IFileProcessorDomainService
         }
     }
 
-    private async Task<Result<T>> ApplyFileImportLogUpdates<T>(Func<FileImportLogAggregate, Task<Result<T>>> action,
+    private async Task<Result> ApplyFileImportLogUpdates(Func<FileImportLogAggregate, Task<Result>> action,
                                                       Guid fileImportLogId,
                                                       CancellationToken cancellationToken,
                                                       Boolean isNotFoundError = true)
@@ -123,14 +122,14 @@ public class FileProcessorDomainService : IFileProcessorDomainService
                 DomainServiceHelper.HandleGetAggregateResult(getFileImportLogResult, fileImportLogId, isNotFoundError);
 
             FileImportLogAggregate fileImportLogAggregate = fileImportLogAggregateResult.Data;
-            Result<T> result = await action(fileImportLogAggregate);
+            Result result = await action(fileImportLogAggregate);
             if (result.IsFailed)
                 return ResultHelpers.CreateFailure(result);
 
             Result saveResult = await this.FileImportLogAggregateRepository.SaveChanges(fileImportLogAggregate, cancellationToken);
             if (saveResult.IsFailed)
                 return ResultHelpers.CreateFailure(saveResult);
-            return Result.Success(result.Data);
+            return Result.Success();
         }
         catch (Exception ex)
         {
@@ -138,7 +137,7 @@ public class FileProcessorDomainService : IFileProcessorDomainService
         }
     }
 
-    public async Task<Result<Guid>> UploadFile(FileCommands.UploadFileCommand command,
+    public async Task<Result> UploadFile(FileCommands.UploadFileCommand command,
                                        CancellationToken cancellationToken) {
         DateTime importLogDateTime = command.FileUploadedDateTime;
 
@@ -149,7 +148,7 @@ public class FileProcessorDomainService : IFileProcessorDomainService
         // This will now create the import log and add an event for the file being uploaded
         Guid importLogId = Helpers.CalculateFileImportLogAggregateId(importLogDateTime.Date, command.EstateId);
 
-        Result<Guid> result = await ApplyFileImportLogUpdates(async (fileImportLogAggregate) => {
+        Result result = await ApplyFileImportLogUpdates(async (fileImportLogAggregate) => {
             if (fileImportLogAggregate.IsCreated == false)
             {
                 // First file of the day so create
@@ -192,23 +191,39 @@ public class FileProcessorDomainService : IFileProcessorDomainService
                     fileContent = await sr.ReadToEndAsync(cancellationToken);
                 }
             }
+            Guid generatedFileId = CreateGuidFromFileData(fileContent);
 
-            Guid fileId = this.CreateGuidFromFileData(fileContent);
-
-            String fileDestination = $"{fileProfile.ListeningDirectory}//{command.EstateId:N}-{fileId:N}";
+            if (generatedFileId != command.FileId) {
+                return Result.Invalid("File content does not match the file id provided");
+            }
+            
+            String fileDestination = $"{fileProfile.ListeningDirectory}//{command.EstateId:N}-{command.FileId:N}";
             file.MoveTo(fileDestination, overwrite: true);
 
             // Update Import log aggregate
-            Result stateResult= fileImportLogAggregate.AddImportedFile(fileId, command.MerchantId, command.UserId, command.FileProfileId, originalName, fileDestination, command.FileUploadedDateTime);
+            Result stateResult= fileImportLogAggregate.AddImportedFile(command.FileId, command.MerchantId, command.UserId, command.FileProfileId, originalName, fileDestination, command.FileUploadedDateTime);
             if (stateResult.IsFailed)
                 return stateResult;
             
-            return Result.Success(fileId);
+            return Result.Success();
         }, importLogId, cancellationToken, false);
         
         return result;
     }
 
+    public static Guid CreateGuidFromFileData(String fileContents)
+    {
+        using (SHA256 sha256Hash = SHA256.Create())
+        {
+            //Generate hash from the key
+            Byte[] bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(fileContents));
+
+            Byte[] j = bytes.Skip(Math.Max(0, bytes.Count() - 16)).ToArray(); //Take last 16
+
+            //Create our Guid.
+            return new Guid(j);
+        }
+    }
     private Result ValidateRequest(FileCommands.UploadFileCommand command) {
         if (command.UserId == Guid.Empty) {
             return Result.Invalid("No User Id provided with file upload");
@@ -399,32 +414,17 @@ public class FileProcessorDomainService : IFileProcessorDomainService
                 OperatorId = contract.OperatorId,
                 ProductId = product.ProductId,
                 AdditionalTransactionMetadata = transactionMetadata,
-                TransactionSource = 2 // File based transaction
+                TransactionSource = 2, // File based transaction
             };
-
-            SerialisedMessage serialisedRequestMessage = new SerialisedMessage
-            {
-                Metadata = new Dictionary<String, String>
-                                                                    {
-                                                                        {"estate_id", fileDetails.EstateId.ToString()},
-                                                                        {"merchant_id", fileDetails.MerchantId.ToString()}
-                                                                    },
-                SerialisedData = JsonConvert.SerializeObject(saleTransactionRequest, new JsonSerializerSettings
-                {
-                    TypeNameHandling = TypeNameHandling.All
-                })
-            };
-
-            Logger.LogDebug(serialisedRequestMessage.SerialisedData);
-
+            
+            
             // Send request to transaction processor
-            Result<SerialisedMessage> result= await this.TransactionProcessorClient.PerformTransaction(this.TokenResponse.AccessToken, serialisedRequestMessage, cancellationToken);
+            Result<SaleTransactionResponse> result= await this.TransactionProcessorClient.PerformTransaction(this.TokenResponse.AccessToken, saleTransactionRequest, cancellationToken);
             if (result.IsFailed)
                 return ResultHelpers.CreateFailure(result);
-            SerialisedMessage serialisedResponseMessage = result.Data;
 
             // Get the sale transaction response
-            SaleTransactionResponse saleTransactionResponse = JsonConvert.DeserializeObject<SaleTransactionResponse>(serialisedResponseMessage.SerialisedData);
+            SaleTransactionResponse saleTransactionResponse = result.Data;
 
             if (saleTransactionResponse.ResponseCode == "0000") {
                 // record response against file line in file aggregate
@@ -442,6 +442,9 @@ public class FileProcessorDomainService : IFileProcessorDomainService
             return Result.Success();
 
         }, command.FileId, cancellationToken);
+
+        if (result.IsFailed)
+            Logger.LogWarning($"{command.LineNumber} Status {result.Status} Message {result.Message}");
 
         return result;
     }
@@ -536,21 +539,7 @@ public class FileProcessorDomainService : IFileProcessorDomainService
     }
 
     private static Int32 TransactionNumber = 0;
-
-    private Guid CreateGuidFromFileData(String fileContents)
-    {
-        using (SHA256 sha256Hash = SHA256.Create())
-        {
-            //Generate hash from the key
-            Byte[] bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(fileContents));
-
-            Byte[] j = bytes.Skip(Math.Max(0, bytes.Count() - 16)).ToArray(); //Take last 16
-
-            //Create our Guid.
-            return new Guid(j);
-        }
-    }
-
+    
     private Boolean FileLineCanBeIgnored(String domainEventFileLine,
                                          String fileProfileFileFormatHandler)
     {

--- a/FileProcessor.Client/FileProcessor.Client.csproj
+++ b/FileProcessor.Client/FileProcessor.Client.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
-    <PackageReference Include="Shared.Results" Version="2026.3.1" />
+    <PackageReference Include="ClientProxyBase" Version="2026.5.6" />
+    <PackageReference Include="Shared.Results" Version="2026.5.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FileProcessor.Client/FileProcessorClient.cs
+++ b/FileProcessor.Client/FileProcessorClient.cs
@@ -1,16 +1,17 @@
-﻿using Shared.Results;
+﻿using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Shared.Results;
 
 namespace FileProcessor.Client {
     using System;
     using System.Collections.Generic;
     using System.Net.Http;
-    using System.Net.Http.Headers;
     using System.Threading;
     using System.Threading.Tasks;
     using ClientProxyBase;
     using DataTransferObjects;
     using DataTransferObjects.Responses;
-    using Newtonsoft.Json;
     using SimpleResults;
 
     /// <summary>
@@ -36,11 +37,11 @@ namespace FileProcessor.Client {
         /// <param name="baseAddressResolver">The base address resolver.</param>
         /// <param name="httpClient">The HTTP client.</param>
         public FileProcessorClient(Func<String, String> baseAddressResolver,
-                                   HttpClient httpClient) : base(httpClient) {
+                                   HttpClient httpClient,
+                                   Func<object, string> serialise,
+                                   Func<string, Type, object> deserialise) : base(httpClient, serialise, deserialise)
+        {
             this.BaseAddressResolver = baseAddressResolver;
-
-            // Add the API version header
-            this.HttpClient.DefaultRequestHeaders.Add("api-version", "1.0");
         }
 
         #endregion
@@ -62,7 +63,7 @@ namespace FileProcessor.Client {
             String requestUri = this.BuildRequestUrl($"/api/files/{fileId}?estateId={estateId}");
 
             try {
-                Result<FileDetails> result = await this.SendHttpGetRequest<FileDetails> (requestUri, accessToken, cancellationToken);
+                Result<FileDetails> result = await this.Get<FileDetails>(requestUri, accessToken, cancellationToken);
 
                 if (result.IsFailed)
                     return ResultHelpers.CreateFailure(result);
@@ -98,7 +99,7 @@ namespace FileProcessor.Client {
             }
 
             try {
-                Result<FileImportLog> result = await this.SendHttpGetRequest<FileImportLog>(requestUri, accessToken, cancellationToken);
+                Result<FileImportLog> result = await this.Get<FileImportLog>(requestUri, accessToken, cancellationToken);
 
                 if (result.IsFailed)
                     return ResultHelpers.CreateFailure(result);
@@ -138,7 +139,7 @@ namespace FileProcessor.Client {
             }
 
             try {
-                Result<FileImportLogList> result = await this.SendHttpGetRequest<FileImportLogList>(requestUri, accessToken, cancellationToken);
+                Result<FileImportLogList> result = await this.Get<FileImportLogList>(requestUri, accessToken, cancellationToken);
 
                 if (result.IsFailed)
                     return ResultHelpers.CreateFailure(result);
@@ -169,42 +170,42 @@ namespace FileProcessor.Client {
                                                    CancellationToken cancellationToken) {
             try {
                 String requestUri = this.BuildRequestUrl("/api/files");
+                
+                List<(string fieldName, string data)> formFields = new();
+                formFields.Add(("EstateId", uploadFileRequest.EstateId.ToString()));
+                formFields.Add(("MerchantId", uploadFileRequest.MerchantId.ToString()));
+                formFields.Add(("FileProfileId", uploadFileRequest.FileProfileId.ToString()));
+                formFields.Add(("UserId", uploadFileRequest.UserId.ToString()));
+                formFields.Add(("UploadDateTime", uploadFileRequest.UploadDateTime.ToString("yyyy-MM-dd HH:mm:ss")));
+                
+                Guid fileId = CreateGuidFromFileData(fileData);
+                formFields.Add(("FileId", fileId.ToString()));
 
-                HttpRequestMessage httpRequest = new HttpRequestMessage(HttpMethod.Post, requestUri);
-                MultipartFormDataContent formData = new MultipartFormDataContent();
-
-                ByteArrayContent fileContent = new ByteArrayContent(fileData);
-                fileContent.Headers.ContentType = MediaTypeHeaderValue.Parse("multipart/form-data");
-                formData.Add(fileContent, "file", fileName);
-                formData.Add(new StringContent(uploadFileRequest.EstateId.ToString()), "EstateId");
-                formData.Add(new StringContent(uploadFileRequest.MerchantId.ToString()), "MerchantId");
-                formData.Add(new StringContent(uploadFileRequest.FileProfileId.ToString()), "FileProfileId");
-                formData.Add(new StringContent(uploadFileRequest.UserId.ToString()), "UserId");
-                formData.Add(new StringContent(uploadFileRequest.UploadDateTime.ToString("yyyy-MM-dd HH:mm:ss")),
-                    "UploadDateTime");
-
-                httpRequest.Content = formData;
-                httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-
-                HttpResponseMessage httpResponse = await this.HttpClient.SendAsync(httpRequest, cancellationToken);
-
-                // Process the response
-                Result<String> result = await this.HandleResponseX(httpResponse, cancellationToken);
-
+                Result result = await this.Post(requestUri, fileData, fileName, formFields, accessToken, cancellationToken);
                 if (result.IsFailed)
                     return ResultHelpers.CreateFailure(result);
 
-                Guid responseData = JsonConvert.DeserializeObject<Guid>(result.Data);
-                
-                // call was successful so now deserialise the body to the response object
-                return Result.Success(responseData);
-
+                return Result.Success(fileId);
             }
             catch (Exception ex) {
                 // An exception has occurred, add some additional information to the message
                 Exception exception = new Exception($"Error uploading file {fileName}.", ex);
 
                 throw exception;
+            }
+        }
+
+        private Guid CreateGuidFromFileData(Byte[] fileContents)
+        {
+            using (SHA256 sha256Hash = SHA256.Create())
+            {
+                //Generate hash from the key
+                Byte[] bytes = sha256Hash.ComputeHash(fileContents);
+
+                Byte[] j = bytes.Skip(Math.Max(0, bytes.Count() - 16)).ToArray(); //Take last 16
+
+                //Create our Guid.
+                return new Guid(j);
             }
         }
 

--- a/FileProcessor.DataTransferObjects/FileProcessor.DataTransferObjects.csproj
+++ b/FileProcessor.DataTransferObjects/FileProcessor.DataTransferObjects.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+	  
 	</ItemGroup>
 
 </Project>

--- a/FileProcessor.DataTransferObjects/Requests/UploadFileRequest.cs
+++ b/FileProcessor.DataTransferObjects/Requests/UploadFileRequest.cs
@@ -2,66 +2,21 @@
 
 namespace FileProcessor.DataTransferObjects
 {
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
-
     /// <summary>
     /// 
     /// </summary>
     public class UploadFileRequest
     {
-        /// <summary>
-        /// Gets or sets the estate identifier.
-        /// </summary>
-        /// <value>
-        /// The estate identifier.
-        /// </value>
-        [JsonProperty("estate_id")]
+        public Guid FileId { get; set; }
+
         public Guid EstateId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the merchant identifier.
-        /// </summary>
-        /// <value>
-        /// The merchant identifier.
-        /// </value>
-        [JsonProperty("merchant_id")]
         public Guid MerchantId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the user identifier.
-        /// </summary>
-        /// <value>
-        /// The user identifier.
-        /// </value>
-        [JsonProperty("user_id")]
         public Guid UserId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the file profile identifier.
-        /// </summary>
-        /// <value>
-        /// The file profile identifier.
-        /// </value>
-        [JsonProperty("file_profile_id")]
         public Guid FileProfileId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the upload date time.
-        /// </summary>
-        /// <value>
-        /// The upload date time.
-        /// </value>
-        [JsonProperty("upload_date_time")]
-        [JsonConverter(typeof(CustomDateTimeConverter))]
         public DateTime UploadDateTime { get; set; }
-    }
-
-    public class CustomDateTimeConverter : IsoDateTimeConverter
-    {
-        public CustomDateTimeConverter()
-        {
-            base.DateTimeFormat = "yyyy-MM-dd HH:mm:ss";
-        }
     }
 }

--- a/FileProcessor.DataTransferObjects/Responses/FileDetails.cs
+++ b/FileProcessor.DataTransferObjects/Responses/FileDetails.cs
@@ -2,107 +2,33 @@
 {
     using System;
     using System.Collections.Generic;
-    using Newtonsoft.Json;
-
+    
     public class FileDetails
     {
-        /// <summary>
-        /// Gets or sets the file identifier.
-        /// </summary>
-        /// <value>
-        /// The file identifier.
-        /// </value>
-        [JsonProperty("file_id")]
         public Guid FileId { get; set; }
 
-        /// <summary>
-        /// Gets or sets a value indicating whether [processing completed].
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if [processing completed]; otherwise, <c>false</c>.
-        /// </value>
-        [JsonProperty("processing_completed")]
         public Boolean ProcessingCompleted { get; set; }
 
-        /// <summary>
-        /// Gets or sets the estate identifier.
-        /// </summary>
-        /// <value>
-        /// The estate identifier.
-        /// </value>
-        [JsonProperty("estate_id")]
         public Guid EstateId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the user identifier.
-        /// </summary>
-        /// <value>
-        /// The user identifier.
-        /// </value>
-        [JsonProperty("user_id")]
         public Guid UserId { get; set; }
 
-        [JsonProperty("user_email_address")]
         public String UserEmailAddress { get; set; }
 
-        /// <summary>
-        /// Gets or sets the merchant identifier.
-        /// </summary>
-        /// <value>
-        /// The merchant identifier.
-        /// </value>
-        [JsonProperty("merchant_id")]
         public Guid MerchantId { get; set; }
 
-        [JsonProperty("merchant_name")]
         public String MerchantName { get; set; }
 
-        /// <summary>
-        /// Gets or sets the file profile identifier.
-        /// </summary>
-        /// <value>
-        /// The file profile identifier.
-        /// </value>
-        [JsonProperty("file_profile_id")]
         public Guid FileProfileId { get; set; }
 
-        [JsonProperty("file_profile_name")]
         public String FileProfileName { get; set; }
 
-        /// <summary>
-        /// Gets or sets the file import log identifier.
-        /// </summary>
-        /// <value>
-        /// The file import log identifier.
-        /// </value>
-        [JsonProperty("file_import_log_id")]
         public Guid FileImportLogId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the file location.
-        /// </summary>
-        /// <value>
-        /// The file location.
-        /// </value>
-        [JsonProperty("file_location")]
         public String FileLocation { get; set; }
 
-        /// <summary>
-        /// Gets or sets the file lines.
-        /// </summary>
-        /// <value>
-        /// The file lines.
-        /// </value>
-        [JsonProperty("file_lines")]
         public List<FileLine> FileLines { get; set; }
 
-        /// <summary>
-        /// Gets or sets the processing summary.
-        /// </summary>
-        /// <value>
-        /// The processing summary.
-        /// </value>
-        [JsonProperty("processing_summary")]
         public FileProcessingSummary ProcessingSummary { get; set; }
     }
 }

--- a/FileProcessor.DataTransferObjects/Responses/FileImportLog.cs
+++ b/FileProcessor.DataTransferObjects/Responses/FileImportLog.cs
@@ -2,65 +2,19 @@
 {
     using System;
     using System.Collections.Generic;
-    using Newtonsoft.Json;
-
-    /// <summary>
-    /// 
-    /// </summary>
+    
     public class FileImportLog
     {
-        /// <summary>
-        /// Gets or sets the file import log identifier.
-        /// </summary>
-        /// <value>
-        /// The file import log identifier.
-        /// </value>
-        [JsonProperty("file_import_log_id")]
         public Guid FileImportLogId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the import log date time.
-        /// </summary>
-        /// <value>
-        /// The import log date time.
-        /// </value>
-        [JsonProperty("import_log_date_time")]
         public DateTime ImportLogDateTime { get; set; }
         
-        /// <summary>
-        /// Gets or sets the import log date.
-        /// </summary>
-        /// <value>
-        /// The import log date.
-        /// </value>
-        [JsonProperty("import_log_date")]
         public DateTime ImportLogDate { get; set; }
 
-        /// <summary>
-        /// Gets or sets the import log time.
-        /// </summary>
-        /// <value>
-        /// The import log time.
-        /// </value>
-        [JsonProperty("import_log_time")]
         public TimeSpan ImportLogTime { get; set; }
 
-        /// <summary>
-        /// Gets or sets the file count.
-        /// </summary>
-        /// <value>
-        /// The file count.
-        /// </value>
-        [JsonProperty("file_count")]
         public Int32 FileCount { get; set; }
 
-        /// <summary>
-        /// Gets or sets the files.
-        /// </summary>
-        /// <value>
-        /// The files.
-        /// </value>
-        [JsonProperty("files")]
         public List<FileImportLogFile> Files { get; set; }
     }
 }

--- a/FileProcessor.DataTransferObjects/Responses/FileImportLogFile.cs
+++ b/FileProcessor.DataTransferObjects/Responses/FileImportLogFile.cs
@@ -1,85 +1,24 @@
 ﻿namespace FileProcessor.DataTransferObjects.Responses
 {
     using System;
-    using Newtonsoft.Json;
-
-    /// <summary>
-    /// 
-    /// </summary>
     public class FileImportLogFile
     {
         #region Properties
 
-        /// <summary>
-        /// Gets or sets the file identifier.
-        /// </summary>
-        /// <value>
-        /// The file identifier.
-        /// </value>
-        [JsonProperty("file_id")]
         public Guid FileId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the file import log identifier.
-        /// </summary>
-        /// <value>
-        /// The file import log identifier.
-        /// </value>
-        [JsonProperty("file_import_log_id")]
         public Guid FileImportLogId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the file path.
-        /// </summary>
-        /// <value>
-        /// The file path.
-        /// </value>
-        [JsonProperty("file_path")]
         public String FilePath { get; set; }
 
-        /// <summary>
-        /// Gets or sets the file profile identifier.
-        /// </summary>
-        /// <value>
-        /// The file profile identifier.
-        /// </value>
-        [JsonProperty("file_profile_id")]
         public Guid FileProfileId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the file uploaded date time.
-        /// </summary>
-        /// <value>
-        /// The file uploaded date time.
-        /// </value>
-        [JsonProperty("file_uploaded_date_time")]
         public DateTime FileUploadedDateTime { get; set; }
 
-        /// <summary>
-        /// Gets or sets the merchant identifier.
-        /// </summary>
-        /// <value>
-        /// The merchant identifier.
-        /// </value>
-        [JsonProperty("merchant_id")]
         public Guid MerchantId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name of the original file.
-        /// </summary>
-        /// <value>
-        /// The name of the original file.
-        /// </value>
-        [JsonProperty("original_file_name")]
         public String OriginalFileName { get; set; }
 
-        /// <summary>
-        /// Gets or sets the user identifier.
-        /// </summary>
-        /// <value>
-        /// The user identifier.
-        /// </value>
-        [JsonProperty("user_id")]
         public Guid UserId { get; set; }
 
         #endregion

--- a/FileProcessor.DataTransferObjects/Responses/FileImportLogList.cs
+++ b/FileProcessor.DataTransferObjects/Responses/FileImportLogList.cs
@@ -1,6 +1,4 @@
-﻿using Newtonsoft.Json;
-
-namespace FileProcessor.DataTransferObjects.Responses
+﻿namespace FileProcessor.DataTransferObjects.Responses
 {
     using System.Collections.Generic;
 
@@ -11,10 +9,6 @@ namespace FileProcessor.DataTransferObjects.Responses
     {
         #region Fields
 
-        /// <summary>
-        /// The file import logs
-        /// </summary>
-        [JsonProperty("file_import_logs")]
         public List<FileImportLog> FileImportLogs { get; set; }
 
         #endregion

--- a/FileProcessor.DataTransferObjects/Responses/FileLine.cs
+++ b/FileProcessor.DataTransferObjects/Responses/FileLine.cs
@@ -1,57 +1,16 @@
 ﻿namespace FileProcessor.DataTransferObjects.Responses
 {
     using System;
-    using Newtonsoft.Json;
-
+    
     public class FileLine
     {
-        #region Properties
-
-        /// <summary>
-        /// Gets or sets the line data.
-        /// </summary>
-        /// <value>
-        /// The line data.
-        /// </value>
-        [JsonProperty("line_data")]
         public String LineData { get; set; }
-
-        /// <summary>
-        /// Gets or sets the line number.
-        /// </summary>
-        /// <value>
-        /// The line number.
-        /// </value>
-        [JsonProperty("line_number")]
         public Int32 LineNumber { get; set; }
 
-        /// <summary>
-        /// Gets or sets a value indicating whether this <see cref="FileLine"/> is ignored.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if ignored; otherwise, <c>false</c>.
-        /// </value>
-        [JsonProperty("processing_result")]
         public FileLineProcessingResult ProcessingResult { get; set; }
 
-        /// <summary>
-        /// Gets or sets the transaction identifier.
-        /// </summary>
-        /// <value>
-        /// The transaction identifier.
-        /// </value>
-        [JsonProperty("transaction_id")]
         public Guid TransactionId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the rejection reason.
-        /// </summary>
-        /// <value>
-        /// The rejection reason.
-        /// </value>
-        [JsonProperty("rejection_reason")]
         public String RejectionReason { get; set; }
-
-        #endregion
     }
 }

--- a/FileProcessor.DataTransferObjects/Responses/FileProcessingSummary.cs
+++ b/FileProcessor.DataTransferObjects/Responses/FileProcessingSummary.cs
@@ -1,66 +1,19 @@
 ﻿namespace FileProcessor.DataTransferObjects.Responses
 {
     using System;
-    using Newtonsoft.Json;
 
     public class FileProcessingSummary
     {
-        #region Properties
-
-        /// <summary>
-        /// Gets or sets the failed lines.
-        /// </summary>
-        /// <value>
-        /// The failed lines.
-        /// </value>
-        [JsonProperty("failed_lines")]
         public Int32 FailedLines { get; set; }
 
-        /// <summary>
-        /// Gets or sets the ignored lines.
-        /// </summary>
-        /// <value>
-        /// The ignored lines.
-        /// </value>
-        [JsonProperty("ignored_lines")]
         public Int32 IgnoredLines { get; set; }
 
-        /// <summary>
-        /// Gets or sets the not processed lines.
-        /// </summary>
-        /// <value>
-        /// The not processed lines.
-        /// </value>
-        [JsonProperty("not_processed_lines")]
         public Int32 NotProcessedLines { get; set; }
 
-        /// <summary>
-        /// Gets or sets the rejected lines.
-        /// </summary>
-        /// <value>
-        /// The rejected lines.
-        /// </value>
-        [JsonProperty("rejected_lines")]
         public Int32 RejectedLines { get; set; }
 
-        /// <summary>
-        /// Gets or sets the successfully processed lines.
-        /// </summary>
-        /// <value>
-        /// The successfully processed lines.
-        /// </value>
-        [JsonProperty("successfully_processed_lines")]
         public Int32 SuccessfullyProcessedLines { get; set; }
 
-        /// <summary>
-        /// Gets or sets the total lines.
-        /// </summary>
-        /// <value>
-        /// The total lines.
-        /// </value>
-        [JsonProperty("total_lines")]
         public Int32 TotalLines { get; set; }
-
-        #endregion
     }
 }

--- a/FileProcessor.File.DomainEvents/FileProcessor.File.DomainEvents.csproj
+++ b/FileProcessor.File.DomainEvents/FileProcessor.File.DomainEvents.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.3.1" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.6" />
 	</ItemGroup>
 
 </Project>

--- a/FileProcessor.FileAggregate/FileProcessor.FileAggregate.csproj
+++ b/FileProcessor.FileAggregate/FileProcessor.FileAggregate.csproj
@@ -7,8 +7,8 @@
 	<ItemGroup>
 		<PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.3.1" />
-		<PackageReference Include="Shared.EventStore" Version="2026.3.1" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.6" />
+		<PackageReference Include="Shared.EventStore" Version="2026.5.6" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/FileProcessor.FileImportLog.DomainEvents/FileProcessor.FileImportLog.DomainEvents.csproj
+++ b/FileProcessor.FileImportLog.DomainEvents/FileProcessor.FileImportLog.DomainEvents.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Shared.DomainDrivenDesign" Version="2026.3.1" />
+    <PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.6" />
   </ItemGroup>
 
 </Project>

--- a/FileProcessor.FileImportLogAggregate/FileProcessor.FileImportLogAggregate.csproj
+++ b/FileProcessor.FileImportLogAggregate/FileProcessor.FileImportLogAggregate.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Shared.EventStore" Version="2026.3.1" />
+    <PackageReference Include="Shared.EventStore" Version="2026.5.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FileProcessor.IntegrationTesting.Helpers/FileProcessor.IntegrationTesting.Helpers.csproj
+++ b/FileProcessor.IntegrationTesting.Helpers/FileProcessor.IntegrationTesting.Helpers.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Shared.IntegrationTesting" Version="2026.3.1" />
-	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.3.2" />
+	  <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.6" />
+	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.4.3-build355" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FileProcessor.IntegrationTests/Common/DockerHelper.cs
+++ b/FileProcessor.IntegrationTests/Common/DockerHelper.cs
@@ -4,11 +4,12 @@ using System.Threading.Tasks;
 
 namespace FileProcessor.IntegrationTests.Common
 {
-    using System.Net.Http;
     using Client;
     using EventStore.Client;
     using SecurityService.Client;
     using Shared.IntegrationTesting;
+    using Shared.Serialisation;
+    using System.Net.Http;
     using TransactionProcessor.Client;
 
     public class DockerHelper : global::Shared.IntegrationTesting.TestContainers.DockerHelper{
@@ -43,6 +44,7 @@ namespace FileProcessor.IntegrationTests.Common
         /// <param name="testingContext">The testing context.</param>
         public DockerHelper(){
             this.TestingContext = new TestingContext();
+            StringSerialiser.Initialise((IStringSerialiser)new SystemTextJsonSerializer(SystemTextJsonSerializer.GetDefaultJsonSerializerOptions()));
         }
 
         #endregion
@@ -90,15 +92,25 @@ namespace FileProcessor.IntegrationTests.Common
                                                                            }
                                                            };
             HttpClient httpClient = new HttpClient(httpMessageHandler);
-            this.SecurityServiceClient = new SecurityServiceClient(SecurityServiceBaseAddressResolver, httpClient);
-            this.FileProcessorClient = new FileProcessorClient(FileProcessorBaseAddressResolver, httpClient);
-            this.TransactionProcessorClient = new TransactionProcessorClient(TransactionProcessorBaseAddressResolver, httpClient);
+            this.SecurityServiceClient = new SecurityServiceClient(SecurityServiceBaseAddressResolver, httpClient, Serialise, Deserialise);
+            this.FileProcessorClient = new FileProcessorClient(FileProcessorBaseAddressResolver, httpClient, Serialise, Deserialise);
+            this.TransactionProcessorClient = new TransactionProcessorClient(TransactionProcessorBaseAddressResolver, httpClient, Serialise, Deserialise);
             this.TestHostHttpClient = new HttpClient(clientHandler);
             this.TestHostHttpClient.BaseAddress = new Uri($"http://127.0.0.1:{this.TestHostServicePort}");
 
             this.ProjectionManagementClient = new EventStoreProjectionManagementClient(ConfigureEventStoreSettings());
         }
-        
+
+        String Serialise(Object arg)
+        {
+            return StringSerialiser.Serialise<Object>(arg, new SerialiserOptions(SerialiserPropertyFormat.SnakeCase));
+        }
+
+        Object Deserialise(String arg, Type type)
+        {
+            return StringSerialiser.DeserializeObject<Object>(arg, type, new SerialiserOptions(SerialiserPropertyFormat.SnakeCase));
+        }
+
         #endregion
     }
 }

--- a/FileProcessor.IntegrationTests/Features/GetFileImportDetails.feature
+++ b/FileProcessor.IntegrationTests/Features/GetFileImportDetails.feature
@@ -86,8 +86,8 @@ Scenario: Get File Import Log Details
 	| D       | 07777777775 | 100     |
 	| T       | 1           |         |
 	And I upload this file for processing
-	| EstateName    | MerchantName    | FileProfileId                        | UserId                               |
-	| Test Estate 1 | Test Merchant 1 | B2A59ABF-293D-4A6B-B81B-7007503C3476 | ABA59ABF-293D-4A6B-B81B-7007503C3476 |
+	| EstateName    | MerchantName    | FileProfileId                        | UserId                               | UploadDateTime |
+	| Test Estate 1 | Test Merchant 1 | B2A59ABF-293D-4A6B-B81B-7007503C3476 | ABA59ABF-293D-4A6B-B81B-7007503C3476 | Today          |
 
 	Given I have a file named 'SafarcomTopup2.txt' with the following contents
 	| Column1 | Column2     | Column3 |
@@ -95,8 +95,8 @@ Scenario: Get File Import Log Details
 	| D       | 07777777776 | 150     |
 	| T       | 1           |         |
 	And I upload this file for processing
-	| EstateName    | MerchantName    | FileProfileId                        | UserId                               |
-	| Test Estate 1 | Test Merchant 2 | B2A59ABF-293D-4A6B-B81B-7007503C3476 | ABA59ABF-293D-4A6B-B81B-7007503C3476 |
+	| EstateName    | MerchantName    | FileProfileId                        | UserId                               | UploadDateTime |
+	| Test Estate 1 | Test Merchant 2 | B2A59ABF-293D-4A6B-B81B-7007503C3476 | ABA59ABF-293D-4A6B-B81B-7007503C3476 | Today          |
 
 	Given I have a file named 'VoucherIssue1.txt' with the following contents
 	| Column1 | Column2    | Column3                      | Column4 |
@@ -105,8 +105,8 @@ Scenario: Get File Import Log Details
 	| D       | Hospital 1 | testrecipient1@recipient.com | 10      |
 	| T       | 1          |                              |         |
 	And I upload this file for processing
-	| EstateName    | MerchantName    | FileProfileId                        | UserId                               |
-	| Test Estate 1 | Test Merchant 1 | 8806EDBC-3ED6-406B-9E5F-A9078356BE99 | ABA59ABF-293D-4A6B-B81B-7007503C3476 |
+	| EstateName    | MerchantName    | FileProfileId                        | UserId                               | UploadDateTime |
+	| Test Estate 1 | Test Merchant 1 | 8806EDBC-3ED6-406B-9E5F-A9078356BE99 | ABA59ABF-293D-4A6B-B81B-7007503C3476 | Today          |
 
 	When I get the 'Test Estate 1' import logs between 'Yesterday' and 'Today' the following data is returned
 	| ImportLogDate | FileCount |

--- a/FileProcessor.IntegrationTests/Features/GetFileImportDetails.feature.cs
+++ b/FileProcessor.IntegrationTests/Features/GetFileImportDetails.feature.cs
@@ -452,12 +452,14 @@ await this.FeatureBackgroundAsync();
                             "EstateName",
                             "MerchantName",
                             "FileProfileId",
-                            "UserId"});
+                            "UserId",
+                            "UploadDateTime"});
                 table17.AddRow(new string[] {
                             "Test Estate 1",
                             "Test Merchant 1",
                             "B2A59ABF-293D-4A6B-B81B-7007503C3476",
-                            "ABA59ABF-293D-4A6B-B81B-7007503C3476"});
+                            "ABA59ABF-293D-4A6B-B81B-7007503C3476",
+                            "Today"});
 #line 88
  await testRunner.AndAsync("I upload this file for processing", ((string)(null)), table17, "And ");
 #line hidden
@@ -484,12 +486,14 @@ await this.FeatureBackgroundAsync();
                             "EstateName",
                             "MerchantName",
                             "FileProfileId",
-                            "UserId"});
+                            "UserId",
+                            "UploadDateTime"});
                 table19.AddRow(new string[] {
                             "Test Estate 1",
                             "Test Merchant 2",
                             "B2A59ABF-293D-4A6B-B81B-7007503C3476",
-                            "ABA59ABF-293D-4A6B-B81B-7007503C3476"});
+                            "ABA59ABF-293D-4A6B-B81B-7007503C3476",
+                            "Today"});
 #line 97
  await testRunner.AndAsync("I upload this file for processing", ((string)(null)), table19, "And ");
 #line hidden
@@ -525,12 +529,14 @@ await this.FeatureBackgroundAsync();
                             "EstateName",
                             "MerchantName",
                             "FileProfileId",
-                            "UserId"});
+                            "UserId",
+                            "UploadDateTime"});
                 table21.AddRow(new string[] {
                             "Test Estate 1",
                             "Test Merchant 1",
                             "8806EDBC-3ED6-406B-9E5F-A9078356BE99",
-                            "ABA59ABF-293D-4A6B-B81B-7007503C3476"});
+                            "ABA59ABF-293D-4A6B-B81B-7007503C3476",
+                            "Today"});
 #line 107
  await testRunner.AndAsync("I upload this file for processing", ((string)(null)), table21, "And ");
 #line hidden

--- a/FileProcessor.IntegrationTests/FileProcessor.IntegrationTests.csproj
+++ b/FileProcessor.IntegrationTests/FileProcessor.IntegrationTests.csproj
@@ -12,23 +12,23 @@
 
   <ItemGroup>
 	  <PackageReference Include="EventStoreProjections" Version="2023.12.3" />
-	  <PackageReference Include="MessagingService.IntegrationTesting.Helpers" Version="2026.2.2" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
+	  <PackageReference Include="MessagingService.IntegrationTesting.Helpers" Version="2026.4.3-build126" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
 	  <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.3" />
 	  <PackageReference Include="NUnit" Version="4.5.1" />
 	  <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
 	  <PackageReference Include="Reqnroll" Version="3.3.3" />
 	  <PackageReference Include="Reqnroll.NUnit" Version="3.3.3" />
-    <PackageReference Include="SecurityService.Client" Version="2026.2.3" />
-    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.2.3" />
-	  <PackageReference Include="Shared" Version="2026.3.1" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.3.1" />
+    <PackageReference Include="SecurityService.Client" Version="2026.4.3-build157" />
+    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.4.3-build157" />
+	  <PackageReference Include="Shared" Version="2026.5.6" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.6" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-	  <PackageReference Include="TransactionProcessor.Client" Version="2026.3.2" />
-	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.3.2" />
+	  <PackageReference Include="TransactionProcessor.Client" Version="2026.4.3-build355" />
+	  <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.4.3-build355" />
     <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/FileProcessor.IntegrationTests/Steps/SharedSteps.cs
+++ b/FileProcessor.IntegrationTests/Steps/SharedSteps.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using SecurityService.DataTransferObjects;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -14,20 +15,18 @@ using AssignOperatorRequest = TransactionProcessor.DataTransferObjects.Requests.
 
 namespace FileProcessor.IntegrationTests.Steps
 {
-    using System.IO;
-    using System.Threading;
     using Common;
     using DataTransferObjects;
     using IntegrationTesting.Helpers;
     using IntegrationTesting.Helpers.FileProcessor.IntegrationTests.Steps;
-    using Newtonsoft.Json;
-    using SecurityService.DataTransferObjects.Requests;
+    using Reqnroll;
     using SecurityService.IntegrationTesting.Helpers;
     using Shared.IntegrationTesting;
     using Shouldly;
-    using Newtonsoft.Json.Linq;
+    using System.Diagnostics.CodeAnalysis;
+    using System.IO;
     using System.Text.Json;
-    using Reqnroll;
+    using System.Threading;
 
     [Binding]
     [Scope(Tag = "shared")]
@@ -66,8 +65,6 @@ namespace FileProcessor.IntegrationTests.Steps
             Byte[] fileData = await File.ReadAllBytesAsync(filePath);
             (EstateDetails1, UploadFileRequest) uploadFileRequest = table.Rows.ToUploadFileRequest(this.TestingContext.Estates, fileData);
 
-            var x = JsonConvert.SerializeObject(uploadFileRequest.Item2);
-            
             await this.FileProcessorSteps.GivenIUploadThisFileForProcessing(this.TestingContext.AccessToken, filePath, fileData, uploadFileRequest.Item1, uploadFileRequest.Item2);
         }
 
@@ -271,10 +268,8 @@ namespace FileProcessor.IntegrationTests.Steps
 
         private async Task<Decimal> GetMerchantBalance(Guid merchantId)
         {
-            JsonElement jsonElement = (JsonElement)await this.TestingContext.DockerHelper.ProjectionManagementClient.GetStateAsync<dynamic>("MerchantBalanceProjection", $"MerchantBalance-{merchantId:N}");
-            JObject jsonObject = JObject.Parse(jsonElement.GetRawText());
-            decimal balanceValue = jsonObject.SelectToken("merchant.balance").Value<decimal>();
-            return balanceValue;
+            MerchantBalanceProjectionState1 balanceState = await this.TestingContext.DockerHelper.ProjectionManagementClient.GetStateAsync<MerchantBalanceProjectionState1>("MerchantBalanceProjection", $"MerchantBalance-{merchantId:N}");
+            return balanceState.merchant.balance;
         }
 
         [Given(@"I make the following manual merchant deposits")]
@@ -298,4 +293,10 @@ namespace FileProcessor.IntegrationTests.Steps
             }
         }
     }
+
+    [ExcludeFromCodeCoverage]
+    public record Merchant(string Id, string Name, int numberOfEventsProcessed, decimal balance);
+    
+    [ExcludeFromCodeCoverage]
+    public record MerchantBalanceProjectionState1(Merchant merchant);
 }

--- a/FileProcessor.Testing/TestData.cs
+++ b/FileProcessor.Testing/TestData.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using FileProcessor.DataTransferObjects.Responses;
+using SecurityService.DataTransferObjects;
 using TransactionProcessor.DataTransferObjects.Responses.Contract;
 using TransactionProcessor.DataTransferObjects.Responses.Merchant;
 using TransactionProcessor.DataTransferObjects.Responses.Operator;
@@ -13,8 +13,6 @@ namespace FileProcessor.Testing
     using FileImportLog.DomainEvents;
     using FileImportLogAggregate;
     using FileProcessor.Models;
-    using Newtonsoft.Json;
-    using SecurityService.DataTransferObjects.Responses;
     using TransactionProcessor.DataTransferObjects;
 
     public class TestData
@@ -343,7 +341,7 @@ namespace FileProcessor.Testing
 
         public static TokenResponse TokenResponse()
         {
-            return SecurityService.DataTransferObjects.Responses.TokenResponse.Create("AccessToken", string.Empty, 100);
+            return SecurityService.DataTransferObjects.TokenResponse.Create("AccessToken", string.Empty, 100);
         }
 
         public static MerchantResponse GetMerchantResponseWithOperator =>
@@ -494,20 +492,7 @@ namespace FileProcessor.Testing
 
             return contractResponses;
         }
-
-        public static SerialisedMessage SerialisedMessageResponseSale => new SerialisedMessage
-                                                                        {
-                                                                            Metadata = new Dictionary<String, String>
-                                                                                       {
-                                                                                           {"EstateId", TestData.EstateId.ToString()},
-                                                                                           {"MerchantId", TestData.MerchantId.ToString()},
-                                                                                       },
-                                                                            SerialisedData = JsonConvert.SerializeObject(TestData.ClientSaleTransactionResponse, new JsonSerializerSettings
-                                                                                {
-                                                                                    TypeNameHandling = TypeNameHandling.All
-                                                                                })
-                                                                        };
-
+        
         public static SaleTransactionResponse ClientSaleTransactionResponse => new SaleTransactionResponse
                                                                               {
                                                                                   TransactionId = TestData.TransactionId,
@@ -516,20 +501,6 @@ namespace FileProcessor.Testing
                                                                                   EstateId = TestData.EstateId,
                                                                                   MerchantId = TestData.MerchantId
                                                                               };
-
-        public static SerialisedMessage SerialisedMessageResponseFailedSale => new SerialisedMessage
-        {
-            Metadata = new Dictionary<String, String>
-                                                                                       {
-                                                                                           {"EstateId", TestData.EstateId.ToString()},
-                                                                                           {"MerchantId", TestData.MerchantId.ToString()},
-                                                                                       },
-            SerialisedData = JsonConvert.SerializeObject(TestData.ClientSaleTransactionFailedResponse, new JsonSerializerSettings
-                                                                                                       {
-                                                                                                           TypeNameHandling = TypeNameHandling.All
-                                                                                                       })
-        };
-
         public static SaleTransactionResponse ClientSaleTransactionFailedResponse => new SaleTransactionResponse
         {
             TransactionId = TestData.TransactionId,
@@ -857,7 +828,7 @@ namespace FileProcessor.Testing
                                                                      };
         
         public static FileCommands.UploadFileCommand UploadFileCommand =>
-            new (TestData.EstateId, TestData.MerchantId, TestData.UserId, FilePathWithName, TestData.FileProfileId, TestData.FileUploadedDateTime);
+            new (FileId, TestData.EstateId, TestData.MerchantId, TestData.UserId, FilePathWithName, TestData.FileProfileId, TestData.FileUploadedDateTime);
         
         public static FileCommands.ProcessUploadedFileCommand ProcessUploadedFileCommand =>
             new (TestData.EstateId, TestData.MerchantId, TestData.FileImportLogId, TestData.FileId, TestData.UserId, TestData.FilePathWithName, TestData.FileProfileId,

--- a/FileProcessor/Bootstrapper/ClientRegistry.cs
+++ b/FileProcessor/Bootstrapper/ClientRegistry.cs
@@ -1,14 +1,16 @@
 ﻿using ClientProxyBase;
+using Shared.EventStore.SubscriptionWorker;
 
 namespace FileProcessor.Bootstrapper;
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Net.Http;
 using Lamar;
 using Microsoft.Extensions.DependencyInjection;
 using SecurityService.Client;
 using Shared.General;
+using Shared.Serialisation;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
 using TransactionProcessor.Client;
 
 [ExcludeFromCodeCoverage]
@@ -30,4 +32,22 @@ public class ClientRegistry : ServiceRegistry
     }
 
     #endregion
+}
+
+[ExcludeFromCodeCoverage]
+public class SerialiserRegistry : ServiceRegistry
+{
+    public SerialiserRegistry()
+    {
+        this.AddSingleton<IStringSerialiser, SystemTextJsonSerializer>();
+        this.AddSingleton<Func<Object, String>>(_ => obj => StringSerialiser.Serialise(obj));
+        this.AddSingleton<Func<String, Type, Object>>(_ => (str, type) => StringSerialiser.DeserializeObject<Object>(str, type));
+
+        var serialiserSettings = SystemTextJsonSerializer.GetDefaultJsonSerializerOptions().AddModifier(JsonTypeInfoModifierExtensions.ForType<PersistentSubscriptionInfo>(typeInfo =>
+        {
+            typeInfo.RenameProperty<PersistentSubscriptionInfo>(x => x.StreamName, "eventStreamId");
+        }));
+
+        this.AddSingleton(serialiserSettings);
+    }
 }

--- a/FileProcessor/Bootstrapper/MiddlewareRegistry.cs
+++ b/FileProcessor/Bootstrapper/MiddlewareRegistry.cs
@@ -3,26 +3,23 @@ using Microsoft.OpenApi;
 
 namespace FileProcessor.Bootstrapper
 {
-    using EventStore.Client;
     using Lamar;
-    using Microsoft.AspNetCore.Authentication.JwtBearer;
     using Microsoft.AspNetCore.Http.Features;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Diagnostics.HealthChecks;
-    using Microsoft.IdentityModel.Tokens;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Serialization;
     using OpenIddict.Validation.AspNetCore;
     using Shared.Authorisation;
     using Shared.EventStore.Extensions;
     using Shared.Extensions;
     using Shared.General;
+    using Shared.Serialisation;
     using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.IO;
     using System.Net.Http;
     using System.Reflection;
+    using System.Text.Json;
 
     [ExcludeFromCodeCoverage]
     public class MiddlewareRegistry : ServiceRegistry
@@ -102,29 +99,18 @@ namespace FileProcessor.Bootstrapper
                 });
 
             this.AddAuthorization();
-        
-            this.AddControllers().AddNewtonsoftJson(options =>
-                                                    {
-                                                        options.SerializerSettings.Culture = new CultureInfo("en-GB");
-                                                        options.SerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore;
-                                                        options.SerializerSettings.TypeNameHandling = TypeNameHandling.None;
-                                                        options.SerializerSettings.Formatting = Formatting.Indented;
-                                                        options.SerializerSettings.DateTimeZoneHandling = DateTimeZoneHandling.Utc;
-                                                        options.SerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
-                                                    });
+
+            this.AddControllers();
+            this.ConfigureHttpJsonOptions(options => {
+                JsonSerializerConfiguration.ConfigureMinimalApi(options.SerializerOptions);
+            });
 
             Assembly assembly = this.GetType().GetTypeInfo().Assembly;
             this.AddMvcCore().AddApplicationPart(assembly).AddControllersAsServices();
 
             this.AddClientCredentialsOnlyPolicy();
             this.AddClientCredentialsHandler();
-
-            this.ConfigureHttpJsonOptions(options =>
-            {
-                options.SerializerOptions.PropertyNamingPolicy = new SnakeCaseNamingPolicy();
-                options.SerializerOptions.PropertyNameCaseInsensitive = true; // optional, but safer
-            });
-
+            
             this.Configure<FormOptions>(options =>
             {
                 // Allow very large values (adjust to what you need)
@@ -158,5 +144,18 @@ namespace FileProcessor.Bootstrapper
         }
 
         #endregion
+    }
+
+    public static class JsonSerializerConfiguration
+    {
+        public static void ConfigureMinimalApi(JsonSerializerOptions serializerOptions)
+        {
+            var defaultOptions = SystemTextJsonSerializer.GetDefaultJsonSerializerOptions();
+            serializerOptions.PropertyNamingPolicy = defaultOptions.PropertyNamingPolicy;
+            serializerOptions.DictionaryKeyPolicy = defaultOptions.DictionaryKeyPolicy;
+            serializerOptions.ReferenceHandler = defaultOptions.ReferenceHandler;
+            serializerOptions.WriteIndented = defaultOptions.WriteIndented;
+            serializerOptions.Converters.Add(new DateTimeSpaceConverter());
+        }
     }
 }

--- a/FileProcessor/Bootstrapper/MiscRegistry.cs
+++ b/FileProcessor/Bootstrapper/MiscRegistry.cs
@@ -27,7 +27,7 @@ public class MiscRegistry : ServiceRegistry
 
         bool logRequests = ConfigurationReader.GetValueOrDefault<Boolean>("MiddlewareLogging", "LogRequests", true);
         bool logResponses = ConfigurationReader.GetValueOrDefault<Boolean>("MiddlewareLogging", "LogResponses", true);
-        LogLevel middlewareLogLevel = ConfigurationReader.GetValueOrDefault<LogLevel>("MiddlewareLogging", "MiddlewareLogLevel", LogLevel.Warning);
+        LogLevel middlewareLogLevel = ConfigurationReader.GetValueOrDefault<LogLevel>("MiddlewareLogging", "MiddlewareLogLevel", LogLevel.Information);
 
         RequestResponseMiddlewareLoggingConfig config =
             new RequestResponseMiddlewareLoggingConfig(middlewareLogLevel, logRequests, logResponses);

--- a/FileProcessor/FileProcessor.csproj
+++ b/FileProcessor/FileProcessor.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
 	  <PackageReference Include="OpenIddict.Validation.AspNetCore" Version="7.4.0" />
 	  <PackageReference Include="OpenIddict.Validation.SystemNetHttp" Version="7.4.0" />
-	  <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
+	  <PackageReference Include="ClientProxyBase" Version="2026.5.6" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
 	  <PackageReference Include="Lamar" Version="15.0.1" />
 	  <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
@@ -17,12 +17,10 @@
 	  <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
 	  <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
 	  <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Shared" Version="2026.3.1" />
+    <PackageReference Include="Shared" Version="2026.5.6" />
 	  <PackageReference Include="NLog.Extensions.Logging" Version="6.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
-    <PackageReference Include="Shared.Results.Web" Version="2026.3.1" />
+    <PackageReference Include="Shared.Results.Web" Version="2026.5.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />

--- a/FileProcessor/Handlers/DomainEventHandlers.cs
+++ b/FileProcessor/Handlers/DomainEventHandlers.cs
@@ -4,8 +4,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Shared.DomainDrivenDesign.EventSourcing;
 using Shared.EventStore.Aggregate;
 using Shared.EventStore.EventHandling;
@@ -14,8 +12,6 @@ using Shared.General;
 using Shared.Logger;
 using Shared.Serialisation;
 using SimpleResults;
-using static FileProcessor.Common.ModelFactory;
-using ModelFactory = FileProcessor.Common.ModelFactory;
 
 namespace FileProcessor.Handlers
 {
@@ -52,7 +48,7 @@ namespace FileProcessor.Handlers
             }
             catch (Exception ex)
             {
-                string domainEventData = JsonConvert.SerializeObject(domainEvent);
+                string domainEventData = StringSerialiser.Serialise(domainEvent);
                 Logger.LogError($"Failed to process event. Data received [{domainEventData}]", ex);
                 throw;
             }
@@ -75,40 +71,18 @@ namespace FileProcessor.Handlers
 
             if (type == null)
                 throw new NotFoundException($"Failed to find a domain event with type {eventType}");
-
-            var resolver = new JsonIgnoreAttributeIgnorerContractResolver();
-            var settings = new JsonSerializerSettings
-            {
-                ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-                TypeNameHandling = TypeNameHandling.All,
-                Formatting = Formatting.Indented,
-                DateTimeZoneHandling = DateTimeZoneHandling.Utc,
-                ContractResolver = resolver
-            };
-
+            
             if (type.IsSubclassOf(typeof(DomainEvent)))
             {
-                string json = JsonConvert.SerializeObject(domainEvent, settings);
+                String json = StringSerialiser.Serialise(domainEvent);
+
+                Logger.LogInformation($"Deserialising event. Type [{type.Name}], Json [{json}]");
 
                 var factory = new DomainEventFactory();
-                string validatedJson = ValidateEvent(json);
-                return factory.CreateDomainEvent(validatedJson, type);
+                return factory.CreateDomainEvent(json, type);
             }
 
             return null;
-        }
-
-        private static string ValidateEvent(string domainEventJson)
-        {
-            var domainEvent = JObject.Parse(domainEventJson);
-
-            if (!domainEvent.ContainsKey("eventId") ||
-                domainEvent["eventId"]!.ToObject<Guid>() == Guid.Empty)
-            {
-                throw new ArgumentException("Domain Event must contain an Event Id");
-            }
-
-            return domainEventJson;
         }
     }
 }

--- a/FileProcessor/Handlers/FileHandlers.cs
+++ b/FileProcessor/Handlers/FileHandlers.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Shared.General;
 using Shared.Results.Web;
+using Shared.Serialisation;
 using SimpleResults;
 
 namespace FileProcessor.Handlers;
@@ -38,7 +39,8 @@ public static class FileHandlers
         if (request.UploadDateTime == DateTime.MinValue)
             request.UploadDateTime = DateTime.Now;
 
-        FileCommands.UploadFileCommand command = new(request.EstateId,
+        FileCommands.UploadFileCommand command = new(request.FileId,
+            request.EstateId,
             request.MerchantId,
             request.UserId,
             fullPath,

--- a/FileProcessor/Startup.cs
+++ b/FileProcessor/Startup.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FileProcessor.Endpoints;
 using ImTools;
+using Shared.Serialisation;
 
 namespace FileProcessor
 {
@@ -68,10 +69,14 @@ namespace FileProcessor
             services.IncludeRegistry<FileRegistry>();
             services.IncludeRegistry<MiscRegistry>();
             services.IncludeRegistry<ClientRegistry>();
-            
+            services.IncludeRegistry<SerialiserRegistry>();
+
             Startup.Container = new Container(services);
 
             Startup.ServiceProvider = services.BuildServiceProvider();
+
+            var serialiser = Container.GetRequiredService<IStringSerialiser>();
+            StringSerialiser.Initialise(serialiser);
         }
 
         public static IServiceProvider ServiceProvider { get; set; }


### PR DESCRIPTION
Refactor file upload to require deterministic FileId based on file content (SHA256 hash), ensuring consistency and preventing duplicates. Replace Newtonsoft.Json with System.Text.Json and a custom serialization abstraction throughout the codebase. Update DTOs, API, middleware, and tests to use new FileId logic and snake_case conventions. Upgrade package dependencies and modernize code style. Integration and feature tests now include FileId and UploadDateTime.

closes #700 