### PR TITLE
Refactor CreateFile to use CreateFileRequest record

### DIFF
--- a/FileProcessor.BusinessLogic/Services/FileProcessorDomainService.cs
+++ b/FileProcessor.BusinessLogic/Services/FileProcessorDomainService.cs
@@ -249,7 +249,8 @@ public class FileProcessorDomainService : IFileProcessorDomainService
                 return ResultHelpers.CreateFailure(operatorIdResult);
 
             Logger.LogWarning("About to Create File");
-            Result stateResult = fileAggregate.CreateFile(command.FileImportLogId, command.EstateId, command.MerchantId, command.UserId, command.FileProfileId, command.FilePath, command.FileUploadedDateTime, operatorIdResult.Data);
+            FileAggregateExtensions.CreateFileRequest request = new(command.FileImportLogId, command.EstateId, command.MerchantId, command.UserId, command.FileProfileId, command.FilePath, command.FileUploadedDateTime, operatorIdResult.Data);
+            Result stateResult = fileAggregate.CreateFile(request);
             if (stateResult.IsFailed)
                 return stateResult;
 

--- a/FileProcessor.FileAggregate.Tests/FileAggregateTests.cs
+++ b/FileProcessor.FileAggregate.Tests/FileAggregateTests.cs
@@ -35,8 +35,8 @@ namespace FileProcessor.FileAggregate.Tests
         public void FileAggregate_CreateFile_FileIsCreated()
         {
             FileAggregate fileAggregate = FileAggregate.Create(TestData.FileId);
-            var result = fileAggregate.CreateFile(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId,
-                                     TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            FileAggregateExtensions.CreateFileRequest request = new(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            var result = fileAggregate.CreateFile(request);
             result.IsSuccess.ShouldBeTrue();
 
             fileAggregate.IsCreated.ShouldBeTrue();
@@ -58,25 +58,19 @@ namespace FileProcessor.FileAggregate.Tests
         public void FileAggregate_CreateFile_FileAlreadyCreated_NoErrorThrown()
         {
             FileAggregate fileAggregate = FileAggregate.Create(TestData.FileId);
-            fileAggregate.CreateFile(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId,
-                                     TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            FileAggregateExtensions.CreateFileRequest createFileRequest = new(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            fileAggregate.CreateFile(createFileRequest);
 
-            var result = fileAggregate.CreateFile(TestData.FileImportLogId,
-                                                         TestData.EstateId,
-                                                         TestData.MerchantId,
-                                                         TestData.UserId,
-                                                         TestData.FileProfileId,
-                                                         TestData.FileLocation,
-                                                         TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
-                            result.IsSuccess.ShouldBeTrue();
+            var result = fileAggregate.CreateFile(createFileRequest);
+            result.IsSuccess.ShouldBeTrue();
         }
 
         [Fact]
         public void FileAggregate_AddFileLine_FileLineAdded()
         {
             FileAggregate fileAggregate = FileAggregate.Create(TestData.FileId);
-            fileAggregate.CreateFile(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId,
-                                     TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            FileAggregateExtensions.CreateFileRequest createFileRequest = new(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            fileAggregate.CreateFile(createFileRequest);
             var result = fileAggregate.AddFileLine(TestData.FileLine);
             result.IsSuccess.ShouldBeTrue();
 
@@ -98,8 +92,8 @@ namespace FileProcessor.FileAggregate.Tests
         public void FileAggregate_AddFileLine_AddDuplicateLine_FileLineIsNotAddedAdded()
         {
             FileAggregate fileAggregate = FileAggregate.Create(TestData.FileId);
-            fileAggregate.CreateFile(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId,
-                                     TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            FileAggregateExtensions.CreateFileRequest createFileRequest = new(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            fileAggregate.CreateFile(createFileRequest);
             fileAggregate.AddFileLine(TestData.FileLine);
             var result = fileAggregate.AddFileLine(TestData.FileLine);
             result.IsSuccess.ShouldBeTrue();
@@ -124,8 +118,8 @@ namespace FileProcessor.FileAggregate.Tests
         public void FileAggregate_RecordFileLineAsSuccessful_FileLineUpdatedAsSuccessful()
         {
             FileAggregate fileAggregate = FileAggregate.Create(TestData.FileId);
-            fileAggregate.CreateFile(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId,
-                                     TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            FileAggregateExtensions.CreateFileRequest createFileRequest = new(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            fileAggregate.CreateFile(createFileRequest);
             fileAggregate.AddFileLine(TestData.FileLine);
             var result = fileAggregate.RecordFileLineAsSuccessful(TestData.LineNumber, TestData.TransactionId);
             result.IsSuccess.ShouldBeTrue();
@@ -161,8 +155,8 @@ namespace FileProcessor.FileAggregate.Tests
         public void FileAggregate_RecordFileLineAsSuccessful_FileHasNoLine_ErrorThrown()
         {
             FileAggregate fileAggregate = FileAggregate.Create(TestData.FileId);
-            fileAggregate.CreateFile(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId,
-                                     TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            FileAggregateExtensions.CreateFileRequest createFileRequest = new(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            fileAggregate.CreateFile(createFileRequest);
 
             var result = fileAggregate.RecordFileLineAsSuccessful(TestData.LineNumber, TestData.TransactionId);
             result.IsFailed.ShouldBeTrue();
@@ -173,8 +167,8 @@ namespace FileProcessor.FileAggregate.Tests
         public void FileAggregate_RecordFileLineAsSuccessful_LineNotFound_ErrorThrown()
         {
             FileAggregate fileAggregate = FileAggregate.Create(TestData.FileId);
-            fileAggregate.CreateFile(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId,
-                                     TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            FileAggregateExtensions.CreateFileRequest createFileRequest = new(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            fileAggregate.CreateFile(createFileRequest);
             fileAggregate.AddFileLine(TestData.FileLine);
             var result = fileAggregate.RecordFileLineAsSuccessful(TestData.NotFoundLineNumber, TestData.TransactionId);
             result.IsFailed.ShouldBeTrue();
@@ -185,8 +179,8 @@ namespace FileProcessor.FileAggregate.Tests
         public void FileAggregate_RecordFileLineAsFailed_FileLineUpdatedAsFailed()
         {
             FileAggregate fileAggregate = FileAggregate.Create(TestData.FileId);
-            fileAggregate.CreateFile(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId,
-                                     TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            FileAggregateExtensions.CreateFileRequest createFileRequest = new(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            fileAggregate.CreateFile(createFileRequest);
             fileAggregate.AddFileLine(TestData.FileLine);
             var result = fileAggregate.RecordFileLineAsFailed(TestData.LineNumber, TestData.TransactionId,TestData.ResponseCodeFailed, TestData.ResponseMessageFailed);
             result.IsSuccess.ShouldBeTrue();
@@ -223,8 +217,8 @@ namespace FileProcessor.FileAggregate.Tests
         public void FileAggregate_RecordFileLineAsFailed_FileHasNoLines_ErrorThrown()
         {
             FileAggregate fileAggregate = FileAggregate.Create(TestData.FileId);
-            fileAggregate.CreateFile(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId,
-                                     TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            FileAggregateExtensions.CreateFileRequest createFileRequest = new(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            fileAggregate.CreateFile(createFileRequest);
 
             var result = fileAggregate.RecordFileLineAsFailed(TestData.LineNumber, TestData.TransactionId, TestData.ResponseCodeFailed, TestData.ResponseMessageFailed);
             result.IsFailed.ShouldBeTrue();
@@ -235,8 +229,8 @@ namespace FileProcessor.FileAggregate.Tests
         public void FileAggregate_RecordFileLineAsFailed_LineNotFound_ErrorThrown()
         {
             FileAggregate fileAggregate = FileAggregate.Create(TestData.FileId);
-            fileAggregate.CreateFile(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId,
-                                     TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            FileAggregateExtensions.CreateFileRequest createFileRequest = new(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            fileAggregate.CreateFile(createFileRequest);
             fileAggregate.AddFileLine(TestData.FileLine);
             var result = fileAggregate.RecordFileLineAsFailed(TestData.NotFoundLineNumber, TestData.TransactionId, TestData.ResponseCodeFailed, TestData.ResponseMessageFailed);
                                             
@@ -248,8 +242,8 @@ namespace FileProcessor.FileAggregate.Tests
         public void FileAggregate_RecordFileLineAsIgnored_FileLineUpdatedAsIgnored()
         {
             FileAggregate fileAggregate = FileAggregate.Create(TestData.FileId);
-            fileAggregate.CreateFile(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId,
-                                     TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            FileAggregateExtensions.CreateFileRequest createFileRequest = new(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            fileAggregate.CreateFile(createFileRequest);
             fileAggregate.AddFileLine(TestData.FileLine);
             var result = fileAggregate.RecordFileLineAsIgnored(TestData.LineNumber);
             result.IsSuccess.ShouldBeTrue();
@@ -285,8 +279,8 @@ namespace FileProcessor.FileAggregate.Tests
         public void FileAggregate_FileAggregate_RecordFileLineAsIgnored_FileHasNoLine_ErrorThrown()
         {
             FileAggregate fileAggregate = FileAggregate.Create(TestData.FileId);
-            fileAggregate.CreateFile(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId,
-                                     TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            FileAggregateExtensions.CreateFileRequest createFileRequest = new(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            fileAggregate.CreateFile(createFileRequest);
 
             var result = fileAggregate.RecordFileLineAsIgnored(TestData.LineNumber);
             
@@ -298,8 +292,8 @@ namespace FileProcessor.FileAggregate.Tests
         public void FileAggregate_RecordFileLineAsIgnored_LineNotFound_ErrorThrown()
         {
             FileAggregate fileAggregate = FileAggregate.Create(TestData.FileId);
-            fileAggregate.CreateFile(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId,
-                                     TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            FileAggregateExtensions.CreateFileRequest createFileRequest = new(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            fileAggregate.CreateFile(createFileRequest);
             fileAggregate.AddFileLine(TestData.FileLine);
             var result = fileAggregate.RecordFileLineAsIgnored(TestData.NotFoundLineNumber);
             
@@ -313,8 +307,8 @@ namespace FileProcessor.FileAggregate.Tests
         public void FileAggregate_RecordFileLineAsRejected_FileLineUpdatedAsRejected()
         {
             FileAggregate fileAggregate = FileAggregate.Create(TestData.FileId);
-            fileAggregate.CreateFile(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId,
-                                     TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            FileAggregateExtensions.CreateFileRequest createFileRequest = new(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            fileAggregate.CreateFile(createFileRequest);
             fileAggregate.AddFileLine(TestData.FileLine);
             var result = fileAggregate.RecordFileLineAsRejected(TestData.LineNumber, TestData.RejectionReason);
             result.IsSuccess.ShouldBeTrue();
@@ -352,8 +346,8 @@ namespace FileProcessor.FileAggregate.Tests
         public void FileAggregate_RecordFileLineAsRejected_FileHasNoLine_ErrorThrown()
         {
             FileAggregate fileAggregate = FileAggregate.Create(TestData.FileId);
-            fileAggregate.CreateFile(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId,
-                                     TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            FileAggregateExtensions.CreateFileRequest createFileRequest = new(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            fileAggregate.CreateFile(createFileRequest);
 
             var result = fileAggregate.RecordFileLineAsRejected(TestData.LineNumber,TestData.RejectionReason);
             
@@ -365,8 +359,8 @@ namespace FileProcessor.FileAggregate.Tests
         public void FileAggregate_RecordFileLineAsRejected_LineNotFound_ErrorThrown()
         {
             FileAggregate fileAggregate = FileAggregate.Create(TestData.FileId);
-            fileAggregate.CreateFile(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId,
-                                     TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            FileAggregateExtensions.CreateFileRequest createFileRequest = new(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.FileLocation, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            fileAggregate.CreateFile(createFileRequest);
             fileAggregate.AddFileLine(TestData.FileLine);
             var result = fileAggregate.RecordFileLineAsRejected(TestData.NotFoundLineNumber, TestData.RejectionReason);
             

--- a/FileProcessor.FileAggregate/FileAggregate.cs
+++ b/FileProcessor.FileAggregate/FileAggregate.cs
@@ -99,12 +99,14 @@ namespace FileProcessor.FileAggregate
             aggregate.IsCompleted = true;
         }
 
-        public static Result CreateFile(this FileAggregate aggregate, Guid fileImportLogId, Guid estateId, Guid merchantId, Guid userId, Guid fileProfileId, String fileLocation, DateTime fileReceivedDateTime, Guid operatorId)
+        public record CreateFileRequest(Guid fileImportLogId, Guid estateId, Guid merchantId, Guid userId, Guid fileProfileId, String fileLocation, DateTime fileReceivedDateTime, Guid operatorId);
+
+        public static Result CreateFile(this FileAggregate aggregate, CreateFileRequest createFileRequest)
         {
             if (aggregate.IsCreated)
                 return Result.Success();
 
-            FileCreatedEvent fileCreatedEvent = new(aggregate.AggregateId, fileImportLogId, estateId, merchantId, userId, fileProfileId, fileLocation, fileReceivedDateTime, operatorId);
+            FileCreatedEvent fileCreatedEvent = new(aggregate.AggregateId, createFileRequest.fileImportLogId, createFileRequest.estateId, createFileRequest.merchantId, createFileRequest.userId, createFileRequest.fileProfileId, createFileRequest.fileLocation, createFileRequest.fileReceivedDateTime, createFileRequest.operatorId);
 
             aggregate.ApplyAndAppend(fileCreatedEvent);
 

--- a/FileProcessor.Testing/TestData.cs
+++ b/FileProcessor.Testing/TestData.cs
@@ -270,7 +270,9 @@ namespace FileProcessor.Testing
         {
             FileAggregate fileAggregate = new FileAggregate();
 
-            fileAggregate.CreateFile( TestData.FileImportLogId,TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.OriginalFileName, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            FileAggregateExtensions.CreateFileRequest createFileRequest = new FileAggregateExtensions.CreateFileRequest(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.OriginalFileName, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+
+            fileAggregate.CreateFile(createFileRequest);
 
             return fileAggregate;
         }
@@ -279,7 +281,9 @@ namespace FileProcessor.Testing
         {
             FileAggregate fileAggregate = new FileAggregate();
 
-            fileAggregate.CreateFile(TestData.FileImportLogId,TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.OriginalFileName, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            FileAggregateExtensions.CreateFileRequest createFileRequest = new FileAggregateExtensions.CreateFileRequest(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.OriginalFileName, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+
+            fileAggregate.CreateFile(createFileRequest);
             fileAggregate.AddFileLine("D,1,2");
 
             return fileAggregate;
@@ -289,7 +293,9 @@ namespace FileProcessor.Testing
         {
             FileAggregate fileAggregate = new FileAggregate();
 
-            fileAggregate.CreateFile(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.OriginalFileName, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            FileAggregateExtensions.CreateFileRequest createFileRequest = new FileAggregateExtensions.CreateFileRequest(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.OriginalFileName, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+
+            fileAggregate.CreateFile(createFileRequest);
             fileAggregate.AddFileLine(String.Empty);
 
             return fileAggregate;
@@ -299,7 +305,8 @@ namespace FileProcessor.Testing
         {
             FileAggregate fileAggregate = new FileAggregate();
 
-            fileAggregate.CreateFile(TestData.FileImportLogId,TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.OriginalFileName, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            FileAggregateExtensions.CreateFileRequest createFileRequest = new FileAggregateExtensions.CreateFileRequest(TestData.FileImportLogId, TestData.EstateId, TestData.MerchantId, TestData.UserId, TestData.FileProfileId, TestData.OriginalFileName, TestData.FileUploadedDateTime, TestData.SafaricomOperatorId);
+            fileAggregate.CreateFile(createFileRequest);
             fileAggregate.AddFileLine("D,1,2");
             fileAggregate.AddFileLine("D,1,3");
             fileAggregate.AddFileLine("D,1,4");


### PR DESCRIPTION
Refactor CreateFile to use CreateFileRequest record

Refactored FileAggregate.CreateFile to accept a CreateFileRequest record instead of multiple parameters. Updated all usages, including tests and helpers, to use the new request object for improved readability and maintainability.