### PR TITLE
Update test projects to use xUnit v3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -56,7 +56,7 @@
     <PackageVersion Include="TransactionProcessor.Client" Version="2026.5.2" />
     <PackageVersion Include="TransactionProcessor.Database" Version="2026.5.2" />
     <PackageVersion Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.5.2" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 </Project>

--- a/FileProcessor.BusinessLogic.Tests/FileProcessor.BusinessLogic.Tests.csproj
+++ b/FileProcessor.BusinessLogic.Tests/FileProcessor.BusinessLogic.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	  <TargetFramework>net10.0</TargetFramework>
-	  <DebugType>Full</DebugType>
+	  <DebugType>None</DebugType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -13,7 +13,7 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/FileProcessor.FileAggregate.Tests/FileProcessor.FileAggregate.Tests.csproj
+++ b/FileProcessor.FileAggregate.Tests/FileProcessor.FileAggregate.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Shouldly" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/FileProcessor.FileImportLogAggregate.Tests/FileProcessor.FileImportLogAggregate.Tests.csproj
+++ b/FileProcessor.FileImportLogAggregate.Tests/FileProcessor.FileImportLogAggregate.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Shouldly" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/FileProcessor.Tests/FileProcessor.Tests.csproj
+++ b/FileProcessor.Tests/FileProcessor.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Replaced all xunit v2 package references with xunit.v3 (3.2.2) in test projects and Directory.Packages.props. Also set DebugType to None in FileProcessor.BusinessLogic.Tests.csproj.

closes #739 