### PR TITLE
Refactor line terminator handling with enum type

### DIFF
--- a/FileProcessor.DataTransferObjects/Requests/CreateFileProfileRequest.cs
+++ b/FileProcessor.DataTransferObjects/Requests/CreateFileProfileRequest.cs
@@ -14,7 +14,7 @@ public class CreateFileProfileRequest
 
     public string OperatorName { get; set; }
 
-    public string LineTerminator { get; set; }
+    public LineTerminatorType? LineTerminator { get; set; }
 
     public string FileFormatHandler { get; set; }
 }

--- a/FileProcessor.DataTransferObjects/Requests/LineTerminatorType.cs
+++ b/FileProcessor.DataTransferObjects/Requests/LineTerminatorType.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace FileProcessor.DataTransferObjects.Requests;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum LineTerminatorType
+{
+    LineFeed = 1,
+
+    CarriageReturnLineFeed = 2,
+
+    CarriageReturn = 3
+}

--- a/FileProcessor.DataTransferObjects/Requests/UpdateFileProfileRequest.cs
+++ b/FileProcessor.DataTransferObjects/Requests/UpdateFileProfileRequest.cs
@@ -10,7 +10,7 @@ public class UpdateFileProfileRequest
 
     public string OperatorName { get; set; }
 
-    public string LineTerminator { get; set; }
+    public LineTerminatorType? LineTerminator { get; set; }
 
     public string FileFormatHandler { get; set; }
 }

--- a/FileProcessor.FileProfileAggregate.Tests/FileProfileAggregateTests.cs
+++ b/FileProcessor.FileProfileAggregate.Tests/FileProfileAggregateTests.cs
@@ -24,7 +24,7 @@ public class FileProfileAggregateTests
             TestData.SafaricomListeningDirectory,
             TestData.SafaricomRequestType,
             TestData.SafaricomOperatorIdentifier,
-            TestData.SafaricomLineTerminator,
+            LineTerminatorType.LineFeed,
             TestData.SafaricomFileFormatHandler));
 
         Result secondCreate = aggregate.CreateProfile(this.CreateProfile(
@@ -33,7 +33,7 @@ public class FileProfileAggregateTests
             TestData.VoucherListeningDirectory,
             TestData.VoucherRequestType,
             TestData.VoucherOperatorIdentifier,
-            TestData.VoucherLineTerminator,
+            LineTerminatorType.LineFeed,
             TestData.VoucherFileFormatHandler));
 
         Result updateName = aggregate.UpdateProfile(TestData.FileProfileId, new UpdateFileProfileRequest
@@ -58,7 +58,7 @@ public class FileProfileAggregateTests
 
         Result updateLineTerminator = aggregate.UpdateProfile(TestData.FileProfileId, new UpdateFileProfileRequest
         {
-            LineTerminator = "\r\n"
+            LineTerminator = LineTerminatorType.CarriageReturnLineFeed
         });
 
         Result updateFileFormatHandler = aggregate.UpdateProfile(TestData.FileProfileId, new UpdateFileProfileRequest
@@ -72,7 +72,7 @@ public class FileProfileAggregateTests
             "/home/txnproc/bulkfiles/duplicate-name",
             "GammaRequest",
             "Gamma Operator",
-            "\n",
+            LineTerminatorType.LineFeed,
             "GammaHandler"));
 
         Result duplicateRequestTypeCreate = aggregate.CreateProfile(this.CreateProfile(
@@ -81,7 +81,7 @@ public class FileProfileAggregateTests
             "/home/txnproc/bulkfiles/duplicate-request",
             TestData.VoucherRequestType,
             "Gamma Operator",
-            "\n",
+            LineTerminatorType.LineFeed,
             "GammaHandler"));
 
         List<FileProcessor.Models.FileProfile> fileProfiles = aggregate.GetAllProfiles();
@@ -128,7 +128,7 @@ public class FileProfileAggregateTests
             TestData.SafaricomListeningDirectory,
             TestData.SafaricomRequestType,
             TestData.SafaricomOperatorIdentifier,
-            TestData.SafaricomLineTerminator,
+            LineTerminatorType.LineFeed,
             TestData.SafaricomFileFormatHandler));
         
         Result updateResult = aggregate.UpdateProfile(TestData.FileProfileId, new UpdateFileProfileRequest
@@ -137,7 +137,7 @@ public class FileProfileAggregateTests
             RequestType = TestData.SafaricomRequestType,
             ListeningDirectory = TestData.SafaricomListeningDirectory,
             OperatorName = TestData.SafaricomOperatorIdentifier,
-            LineTerminator = TestData.SafaricomLineTerminator,
+            LineTerminator = LineTerminatorType.LineFeed,
             FileFormatHandler = TestData.SafaricomFileFormatHandler
         });
 
@@ -154,7 +154,7 @@ public class FileProfileAggregateTests
             TestData.SafaricomListeningDirectory,
             TestData.SafaricomRequestType,
             TestData.SafaricomOperatorIdentifier,
-            TestData.SafaricomLineTerminator,
+            LineTerminatorType.LineFeed,
             TestData.SafaricomFileFormatHandler));
 
         Result updateResult = aggregate.UpdateProfile(TestData.FileProfileId, new UpdateFileProfileRequest
@@ -182,7 +182,7 @@ public class FileProfileAggregateTests
             TestData.SafaricomListeningDirectory,
             TestData.SafaricomRequestType,
             TestData.SafaricomOperatorIdentifier,
-            TestData.SafaricomLineTerminator,
+            LineTerminatorType.LineFeed,
             TestData.SafaricomFileFormatHandler));
 
         Result duplicateCreate = aggregate.CreateProfile(this.CreateProfile(
@@ -191,12 +191,49 @@ public class FileProfileAggregateTests
             "/tmp/other",
             "DifferentRequest",
             "Other",
-            TestData.SafaricomLineTerminator,
+            LineTerminatorType.LineFeed,
             "OtherHandler"));
 
         firstCreate.IsSuccess.ShouldBeTrue();
         duplicateCreate.IsFailed.ShouldBeTrue();
         duplicateCreate.Status.ShouldBe(ResultStatus.Invalid);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    public void FileProfileAggregate_Create_WithInvalidTerminator_IsRejected(LineTerminatorType? lineTerminator)
+    {
+        FileProfileAggregateRoot aggregate = FileProfileAggregateRoot.Create();
+
+        Result firstCreate = aggregate.CreateProfile(this.CreateProfile(
+            TestData.FileProfileId,
+            TestData.SafaricomProfileName,
+            TestData.SafaricomListeningDirectory,
+            TestData.SafaricomRequestType,
+            TestData.SafaricomOperatorIdentifier,
+            lineTerminator,
+            TestData.SafaricomFileFormatHandler));
+
+        firstCreate.IsFailed.ShouldBeTrue();
+        firstCreate.Status.ShouldBe(ResultStatus.Invalid);
+    }
+
+    [Fact]
+    public void FileProfileAggregate_Create_WithUnknownTerminator_IsRejected()
+    {
+        FileProfileAggregateRoot aggregate = FileProfileAggregateRoot.Create();
+
+        Result firstCreate = aggregate.CreateProfile(this.CreateProfile(
+            TestData.FileProfileId,
+            TestData.SafaricomProfileName,
+            TestData.SafaricomListeningDirectory,
+            TestData.SafaricomRequestType,
+            TestData.SafaricomOperatorIdentifier,
+            (LineTerminatorType?)99,
+            TestData.SafaricomFileFormatHandler));
+
+        firstCreate.IsFailed.ShouldBeTrue();
+        firstCreate.Status.ShouldBe(ResultStatus.Invalid);
     }
 
     [Fact]
@@ -210,7 +247,7 @@ public class FileProfileAggregateTests
             TestData.SafaricomListeningDirectory,
             TestData.SafaricomRequestType,
             TestData.SafaricomOperatorIdentifier,
-            TestData.SafaricomLineTerminator,
+            LineTerminatorType.LineFeed,
             TestData.SafaricomFileFormatHandler));
 
         Result duplicateCreate = aggregate.CreateProfile(this.CreateProfile(
@@ -219,7 +256,7 @@ public class FileProfileAggregateTests
             "/tmp/other",
             TestData.SafaricomRequestType,
             "Other",
-            TestData.SafaricomLineTerminator,
+            LineTerminatorType.LineFeed,
             "OtherHandler"));
 
         firstCreate.IsSuccess.ShouldBeTrue();
@@ -232,7 +269,7 @@ public class FileProfileAggregateTests
                                                    string listeningDirectory,
                                                    string requestType,
                                                    string operatorName,
-                                                   string lineTerminator,
+                                                   LineTerminatorType? lineTerminator,
                                                    string fileFormatHandler)
     {
         return new CreateFileProfileRequest

--- a/FileProcessor.FileProfileAggregate/FileProfileAggregate.cs
+++ b/FileProcessor.FileProfileAggregate/FileProfileAggregate.cs
@@ -8,6 +8,7 @@ using FileProcessor.FileProfile.DomainEvents;
 using Shared.DomainDrivenDesign.EventSourcing;
 using Shared.EventStore.Aggregate;
 using Shared.General;
+using Shared.Results;
 using SimpleResults;
 using FileProfileModel = FileProcessor.Models.FileProfile;
 
@@ -93,13 +94,17 @@ public static class FileProfileAggregateExtensions
             return Result.Invalid($"File profile [{request.FileProfileId}] already exists");
         }
 
+        var lineTerminatorResult = request.LineTerminator.Value.ToLineTerminator();
+        if (lineTerminatorResult.IsFailed)
+            return ResultHelpers.CreateFailure(lineTerminatorResult);
+
         FileProfileCreatedEvent fileProfileCreatedEvent = new(aggregate.AggregateId,
                                                               request.FileProfileId,
                                                               request.Name.Trim(),
                                                               request.ListeningDirectory.Trim(),
                                                               request.RequestType.Trim(),
                                                               request.OperatorName.Trim(),
-                                                              request.LineTerminator,
+                                                              lineTerminatorResult.Data,
                                                               request.FileFormatHandler.Trim());
 
         aggregate.ApplyAndAppend(fileProfileCreatedEvent);
@@ -135,12 +140,19 @@ public static class FileProfileAggregateExtensions
             aggregate.ApplyAndAppend(new FileProfileOperatorNameUpdatedEvent(aggregate.AggregateId, fileProfileId, request.OperatorName));
         }
 
-        if (IsDomainEventRequired(profile.FileFormatHandler, request.FileFormatHandler)) {
-            aggregate.ApplyAndAppend(new FileProfileFileFormatHandlerUpdatedEvent(aggregate.AggregateId, fileProfileId, request.FileFormatHandler));
+        if (request.LineTerminator.HasValue) {
+            Result<String> lineTerminatorResult = request.LineTerminator.Value.ToLineTerminator();
+            if (lineTerminatorResult.IsFailed) {
+                return ResultHelpers.CreateFailure(lineTerminatorResult);
+            }
+
+            if (IsDomainEventRequired(profile.LineTerminator, lineTerminatorResult.Data)) {
+                aggregate.ApplyAndAppend(new FileProfileLineTerminatorUpdatedEvent(aggregate.AggregateId, fileProfileId, lineTerminatorResult.Data));
+            }
         }
 
-        if (IsDomainEventRequired(profile.LineTerminator, request.LineTerminator)) {
-            aggregate.ApplyAndAppend(new FileProfileLineTerminatorUpdatedEvent(aggregate.AggregateId, fileProfileId, request.LineTerminator));
+        if (IsDomainEventRequired(profile.FileFormatHandler, request.FileFormatHandler)) {
+            aggregate.ApplyAndAppend(new FileProfileFileFormatHandlerUpdatedEvent(aggregate.AggregateId, fileProfileId, request.FileFormatHandler));
         }
 
         return Result.Success();
@@ -270,18 +282,42 @@ public static class FileProfileAggregateExtensions
                Comparer.Equals(profile.ListeningDirectory, request.ListeningDirectory.Trim()) &&
                Comparer.Equals(profile.RequestType, request.RequestType.Trim()) &&
                Comparer.Equals(profile.OperatorName, request.OperatorName.Trim()) &&
-               Comparer.Equals(profile.LineTerminator, request.LineTerminator) &&
+               Comparer.Equals(profile.LineTerminator, request.LineTerminator.Value.ToLineTerminator()) &&
                Comparer.Equals(profile.FileFormatHandler, request.FileFormatHandler.Trim()) &&
                profile.IsArchived == false;
     }
 
     private static Result ValidateRequiredCreateFields(CreateFileProfileRequest request)
     {
-        return ValidateStringField(request.ListeningDirectory, "No listening directory provided") ??
-               ValidateStringField(request.RequestType, "No request type provided") ??
-               ValidateStringField(request.OperatorName, "No operator name provided") ??
-               ValidateStringField(request.LineTerminator, "No line terminator provided") ??
-               ValidateStringField(request.FileFormatHandler, "No file format handler provided");
+        var errors = new List<string>();
+
+        AddIfInvalid(request.ListeningDirectory, "No listening directory provided", errors);
+        AddIfInvalid(request.RequestType, "No request type provided", errors);
+        AddIfInvalid(request.OperatorName, "No operator name provided", errors);
+        AddLineTerminatorIfInvalid(request.LineTerminator, "No line terminator provided", errors);
+        AddIfInvalid(request.FileFormatHandler, "No file format handler provided", errors);
+
+        return errors.Count == 0
+            ? Result.Success()
+            : Result.Invalid(errors);
+    }
+
+    private static void AddIfInvalid(string? value, string errorMessage, ICollection<string> errors)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            errors.Add(errorMessage);
+        }
+    }
+
+    private static void AddLineTerminatorIfInvalid(LineTerminatorType? value,
+                                                   string errorMessage,
+                                                   ICollection<string> errors)
+    {
+        if (value.HasValue == false || Enum.IsDefined(typeof(LineTerminatorType), value.Value) == false)
+        {
+            errors.Add(errorMessage);
+        }
     }
 
     private static Result ValidateProposedUpdateValues(UpdateFileProfileRequest request)
@@ -290,8 +326,20 @@ public static class FileProfileAggregateExtensions
                ValidateOptionalStringField(request.ListeningDirectory, "No listening directory provided") ??
                ValidateOptionalStringField(request.RequestType, "No request type provided") ??
                ValidateOptionalStringField(request.OperatorName, "No operator name provided") ??
-               ValidateOptionalStringField(request.LineTerminator, "No line terminator provided") ??
+               ValidateOptionalLineTerminatorField(request.LineTerminator, "No line terminator provided") ??
                ValidateOptionalStringField(request.FileFormatHandler, "No file format handler provided");
+    }
+
+    private static Result ValidateOptionalLineTerminatorField(LineTerminatorType? value, string errorMessage)
+    {
+        if (value.HasValue == false)
+        {
+            return Result.Success();
+        }
+
+        return Enum.IsDefined(typeof(LineTerminatorType), value.Value)
+            ? Result.Success()
+            : Result.Invalid(errorMessage);
     }
 
     private static Result ValidateCreateUniqueness(this FileProfileAggregate aggregate, CreateFileProfileRequest request)
@@ -392,6 +440,20 @@ public static class FileProfileAggregateExtensions
                                     fileProfile.OperatorName,
                                     fileProfile.LineTerminator,
                                     fileProfile.FileFormatHandler);
+    }
+}
+
+public static class LineTerminatorTypeExtensions
+{
+    public static Result<string> ToLineTerminator(this LineTerminatorType lineTerminator)
+    {
+        return lineTerminator switch
+        {
+            LineTerminatorType.LineFeed => Result.Success<string>("\n"),
+            LineTerminatorType.CarriageReturnLineFeed => Result.Success<string>("\r\n"),
+            LineTerminatorType.CarriageReturn => Result.Success<string>("\r"),
+            _ => Result.Invalid($"Invalid line terminator type {lineTerminator}")
+        };
     }
 }
 

--- a/FileProcessor.IntegrationTests/Features/FileProfileSteps.cs
+++ b/FileProcessor.IntegrationTests/Features/FileProfileSteps.cs
@@ -57,7 +57,7 @@ public class FileProfileSteps
             string basedOn = row["BasedOn"];
             FileProfile sourceProfile = await this.GetProfileByAlias(basedOn);
 
-            CreateFileProfileRequest request = duplicateType.Equals("Name", StringComparison.OrdinalIgnoreCase)
+                CreateFileProfileRequest request = duplicateType.Equals("Name", StringComparison.OrdinalIgnoreCase)
                 ? new CreateFileProfileRequest
                 {
                     FileProfileId = Guid.NewGuid(),
@@ -65,7 +65,7 @@ public class FileProfileSteps
                     ListeningDirectory = $"/tmp/{Guid.NewGuid():N}",
                     RequestType = $"{sourceProfile.RequestType}-duplicate",
                     OperatorName = sourceProfile.OperatorName,
-                    LineTerminator = sourceProfile.LineTerminator,
+                    LineTerminator = ParseLineTerminator(sourceProfile.LineTerminator),
                     FileFormatHandler = sourceProfile.FileFormatHandler
                 }
                 : new CreateFileProfileRequest
@@ -75,7 +75,7 @@ public class FileProfileSteps
                     ListeningDirectory = $"/tmp/{Guid.NewGuid():N}",
                     RequestType = sourceProfile.RequestType,
                     OperatorName = sourceProfile.OperatorName,
-                    LineTerminator = sourceProfile.LineTerminator,
+                    LineTerminator = ParseLineTerminator(sourceProfile.LineTerminator),
                     FileFormatHandler = sourceProfile.FileFormatHandler
                 };
 
@@ -125,7 +125,7 @@ public class FileProfileSteps
             ListeningDirectory = row["ListeningDirectory"],
             RequestType = row["RequestType"],
             OperatorName = row["OperatorName"],
-            LineTerminator = row["LineTerminator"],
+            LineTerminator = ParseLineTerminator(row["LineTerminator"]),
             FileFormatHandler = row["FileFormatHandler"]
         };
     }
@@ -148,8 +148,25 @@ public class FileProfileSteps
             ListeningDirectory = row["ListeningDirectory"],
             RequestType = row["RequestType"],
             OperatorName = row["OperatorName"],
-            LineTerminator = row["LineTerminator"],
+            LineTerminator = ParseLineTerminator(row["LineTerminator"]),
             FileFormatHandler = row["FileFormatHandler"]
+        };
+    }
+
+    private static LineTerminatorType? ParseLineTerminator(string lineTerminator)
+    {
+        if (string.IsNullOrWhiteSpace(lineTerminator))
+        {
+            return null;
+        }
+
+        return lineTerminator switch
+        {
+            "\n" => LineTerminatorType.LineFeed,
+            "\r\n" => LineTerminatorType.CarriageReturnLineFeed,
+            "\r" => LineTerminatorType.CarriageReturn,
+            _ when Enum.TryParse<LineTerminatorType>(lineTerminator, true, out LineTerminatorType parsed) => parsed,
+            _ => throw new ArgumentOutOfRangeException(nameof(lineTerminator), lineTerminator, "Unsupported line terminator value")
         };
     }
 


### PR DESCRIPTION
Replaced string-based line terminator properties with a new LineTerminatorType enum in file profile requests. Updated all usages, validation, and tests to use the strongly-typed enum. Added extension methods for conversion and enhanced validation to reject invalid or unknown values. Updated test cases and step definitions to support the new approach.