### PR TITLE
Return early on sync failure, log warning instead

### DIFF
--- a/FileProcessor/Common/Extensions.cs
+++ b/FileProcessor/Common/Extensions.cs
@@ -79,7 +79,7 @@ public static class Extensions
         if (syncResult.IsFailed)
         {
             Logger.LogWarning($"Error getting file profiles {syncResult.Message}");
-            throw new ApplicationStartupException(syncResult.Message);
+            return;
         }
 
         Result recoveryResult = recoveryService.RecoverInProgressFilesAsync(CancellationToken.None).GetAwaiter().GetResult();


### PR DESCRIPTION
Replaced ApplicationStartupException with early return when syncResult.IsFailed is true. Now logs a warning and exits the method gracefully if file profile retrieval fails, improving error handling without terminating the application.